### PR TITLE
list-bundles subcommand

### DIFF
--- a/internal/cmd/list_bundles.go
+++ b/internal/cmd/list_bundles.go
@@ -22,7 +22,7 @@ var (
 	listBundlesCmd = &cobra.Command{
 		Use:     "list-bundles",
 		Short:   "List all the bundles present in an index image.",
-		Example: strings.Join(validateExamples, "\n"),
+		Example: strings.Join(listBundlesExamples, "\n"),
 		Args:    cobra.ExactArgs(1),
 		Run:     listBundlesMain,
 	}

--- a/internal/cmd/list_bundles.go
+++ b/internal/cmd/list_bundles.go
@@ -30,16 +30,18 @@ var (
 
 func listBundlesMain(cmd *cobra.Command, args []string) {
 	indexImageUrl := args[0]
-	allBundles, err := utils.ExtractAndParseAllAddons(indexImageUrl)
+	allBundles, err := utils.ExtractAndParseAddons(indexImageUrl, utils.AllAddonsIdentifier)
 	if err != nil {
 		log.Fatalf("Failed to extract and parse bundles from the given index image: Error: %s \n", err.Error())
 	}
-
+	var operatorVersionedNames []string
 	for _, bundle := range allBundles {
 		version, err := bundle.Version()
 		if err != nil {
-			log.Fatalf("Failed to parse bundle: %s. Error: %s", bundle.Name, err.Error())
+			log.Fatalf("Failed to extract version info for bundle: %s. Error: %s", bundle.Name, err.Error())
 		}
-		fmt.Printf("%s.v%s\n", bundle.Name, version)
+		currentVersionedName := fmt.Sprintf("%s.v%s", bundle.Name, version)
+		operatorVersionedNames = append(operatorVersionedNames, currentVersionedName)
 	}
+	fmt.Println(strings.Join(operatorVersionedNames, "\n"))
 }

--- a/internal/cmd/list_bundles.go
+++ b/internal/cmd/list_bundles.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/mt-sre/addon-metadata-operator/pkg/utils"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	mtcli.AddCommand(listBundlesCmd)
+}
+
+var (
+	listBundlesExamples = []string{
+		"  #List all the bundles present in an index image.",
+		"  mtcli list-bundles <index_image>",
+	}
+	listBundlesCmd = &cobra.Command{
+		Use:     "list-bundles",
+		Short:   "List all the bundles present in an index image.",
+		Example: strings.Join(validateExamples, "\n"),
+		Args:    cobra.ExactArgs(1),
+		Run:     listBundlesMain,
+	}
+)
+
+func listBundlesMain(cmd *cobra.Command, args []string) {
+	indexImageUrl := args[0]
+	allBundles, err := utils.ExtractAndParseAllAddons(indexImageUrl)
+	if err != nil {
+		log.Fatalf("Failed to extract and parse bundles from the given index image: Error: %s \n", err.Error())
+	}
+
+	for _, bundle := range allBundles {
+		version, err := bundle.Version()
+		if err != nil {
+			log.Fatalf("Failed to parse bundle: %s. Error: %s", bundle.Name, err.Error())
+		}
+		fmt.Printf("%s.v%s\n", bundle.Name, version)
+	}
+}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -55,7 +55,7 @@ func validateMain(cmd *cobra.Command, args []string) {
 		log.Fatalf("Could not load addon metadata from file %v, got %v.\n", addonURI, err)
 	}
 
-	bundles, err := utils.ExtractAndParseAddon(addonMetadata.IndexImage, addonMetadata.OperatorName)
+	bundles, err := utils.ExtractAndParseAddons(addonMetadata.IndexImage, addonMetadata.OperatorName)
 	if err != nil {
 		log.Fatalf("Failed to extract and parse bundles from the given index image: Error: %s \n", err.Error())
 	}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -55,7 +55,7 @@ func validateMain(cmd *cobra.Command, args []string) {
 		log.Fatalf("Could not load addon metadata from file %v, got %v.\n", addonURI, err)
 	}
 
-	bundles, err := utils.ExtractAndParse(addonMetadata.IndexImage, addonMetadata.OperatorName)
+	bundles, err := utils.ExtractAndParseAddon(addonMetadata.IndexImage, addonMetadata.OperatorName)
 	if err != nil {
 		log.Fatalf("Failed to extract and parse bundles from the given index image: Error: %s \n", err.Error())
 	}

--- a/pkg/utils/bundle_utils.go
+++ b/pkg/utils/bundle_utils.go
@@ -2,29 +2,33 @@ package utils
 
 import (
 	"errors"
+	"io/ioutil"
 
 	"github.com/operator-framework/operator-registry/pkg/registry"
 	log "github.com/sirupsen/logrus"
 )
 
+const allAddonsKey = "all"
+
 var (
-	bundleParser        BundleParser
-	indexImageExtractor IndexImageExtractor
+	bundleParser BundleParser
 )
 
 func init() {
-	indexImageExtractor = DefaultIndexImageExtractor{
-		downloadPath:  defaultDownloadPath,
-		cacheLocation: defaultCacheLocation,
-	}
 	bundleParser = DefaultBundleParser{}
-
 }
 
-func ExtractAndParse(indexImage, addonName string) ([]registry.Bundle, error) {
+func ExtractAndParseAddon(indexImage, addonName string) ([]registry.Bundle, error) {
 	if indexImage == "" {
 		return []registry.Bundle{}, errors.New("Missing index image!")
 	}
+
+	indexImageExtractor := DefaultIndexImageExtractor{
+		downloadPath: defaultDownloadPath,
+		cacheDir:     defaultCacheDir,
+		indexImage:   indexImage,
+	}
+
 	key := indexImageExtractor.CacheKey(indexImage, addonName)
 	if !indexImageExtractor.CacheHit(key) {
 		if err := indexImageExtractor.ExtractBundlesFromImage(indexImage, indexImageExtractor.ExtractionPath()); err != nil {
@@ -36,4 +40,55 @@ func ExtractAndParse(indexImage, addonName string) ([]registry.Bundle, error) {
 	}
 	manifestsDir := indexImageExtractor.ManifestsPath(addonName)
 	return bundleParser.ParseBundles(addonName, manifestsDir)
+}
+
+func ExtractAndParseAllAddons(indexImage string) ([]registry.Bundle, error) {
+	if indexImage == "" {
+		return []registry.Bundle{}, errors.New("Missing index image!")
+	}
+	indexImageExtractor := DefaultIndexImageExtractor{
+		downloadPath: defaultDownloadPath,
+		cacheDir:     defaultCacheDir,
+		indexImage:   indexImage,
+	}
+	key := indexImageExtractor.CacheKey(indexImage, allAddonsKey)
+
+	if !indexImageExtractor.CacheHit(key) {
+		if err := indexImageExtractor.ExtractBundlesFromImage(indexImage, indexImageExtractor.ExtractionPath()); err != nil {
+			return []registry.Bundle{}, err
+		}
+		if err := indexImageExtractor.WriteToCache(key); err != nil {
+			log.Warnln("Failed to cache the index image bundles")
+		}
+	}
+	operatorsFound, err := allOperatorsFound(indexImageExtractor.ExtractionPath())
+	if err != nil {
+		return []registry.Bundle{}, err
+	}
+
+	var allBundles []registry.Bundle
+	for _, operator := range operatorsFound {
+		manifestsDir := indexImageExtractor.ManifestsPath(operator)
+		bundles, err := bundleParser.ParseBundles(operator, manifestsDir)
+		if err != nil {
+			return []registry.Bundle{}, err
+		}
+		allBundles = append(allBundles, bundles...)
+	}
+
+	return allBundles, nil
+}
+
+func allOperatorsFound(path string) ([]string, error) {
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		return []string{}, err
+	}
+	operatorsFound := []string{}
+	for _, file := range files {
+		if file.IsDir() {
+			operatorsFound = append(operatorsFound, file.Name())
+		}
+	}
+	return operatorsFound, nil
 }


### PR DESCRIPTION
This PR adds a new subcommand `list-bundles` to list the operator bundles present in an index image