### PR TITLE
change how operator name is constructed from a parsed bundle

### DIFF
--- a/integration/mtcli/list_bundles_test.go
+++ b/integration/mtcli/list_bundles_test.go
@@ -60,7 +60,7 @@ func (s *e2eTestSuite) TestMtcliListBundlesE2E() {
 				"ocs-osd-deployer.v1.0.2",
 				"ocs-osd-deployer.v1.1.0",
 				"ocs-osd-deployer.v1.1.1",
-				"ose-prometheus-operator.v4.8.0",
+				"ose-prometheus-operator.4.8.0",
 			},
 		},
 	}

--- a/internal/cmd/list_bundles.go
+++ b/internal/cmd/list_bundles.go
@@ -36,12 +36,11 @@ func listBundlesMain(cmd *cobra.Command, args []string) {
 	}
 	var operatorVersionedNames []string
 	for _, bundle := range allBundles {
-		version, err := bundle.Version()
+		csv, err := bundle.ClusterServiceVersion()
 		if err != nil {
 			log.Fatalf("Failed to extract version info for bundle: %s. Error: %s", bundle.Name, err.Error())
 		}
-		currentVersionedName := fmt.Sprintf("%s.v%s", bundle.Name, version)
-		operatorVersionedNames = append(operatorVersionedNames, currentVersionedName)
+		operatorVersionedNames = append(operatorVersionedNames, csv.GetName())
 	}
 	fmt.Println(strings.Join(operatorVersionedNames, "\n"))
 }


### PR DESCRIPTION
This PR changes how operator names are constructed from a parsed bundle. Earlier, we were constructing the name from the package name + version. Turns out this is not ideal as some operators can have different package name compared to the name in the CSV.
Signed-off-by: ashish <asnaraya@redhat.com>