### PR TITLE
Change CI docker image.

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,6 +1,8 @@
 # vi:set ft=dockerfile:
 # --- stage 1 ---
-FROM registry.ci.openshift.org/openshift/release:golang-1.16 as builder
+FROM registry.redhat.io/rhel8/go-toolset:1.16 as builder
+
+USER root
 
 WORKDIR /build
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,15 +1,9 @@
 # vi: set ft=dockerfile:
-FROM registry.ci.openshift.org/openshift/release:golang-1.16
+FROM registry.redhat.io/rhel8/go-toolset:1.16
 
 USER root
 
 WORKDIR /addon-metadata-operator
-
-# Need latest version of git for goreleaser
-# https://packages.endpoint.com/
-RUN yum -y remove git \
-    && yum -y install https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.9-1.x86_64.rpm \
-    && yum -y install git
 
 # setup goreleaser
 RUN curl -sL https://git.io/goreleaser -o /tmp/goreleaser.sh \


### PR DESCRIPTION
The image we were using is now private and can't be pulled.

This is a fix. Tested both `pr_check.sh` and `build_tag.sh` locally.