### PR TITLE
Add a --disable/--enabled flag to validate cmd.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,12 @@ all: build
 ##@ Development
 
 test: ## Run tests.
-	@go test -count=1 $(PKGS)
+	@go test -count=1 -race $(PKGS)
 
 
 test-e2e: ## Run e2e integration tests
 	@CGO_ENABLED=1 go build -mod=vendor -a -o $(E2E_MTCLI_PATH) cmd/mtcli/main.go
-	@E2E_MTCLI_PATH=$(E2E_MTCLI_PATH) go test $(INTEGRATION_TESTS)
+	@E2E_MTCLI_PATH=$(E2E_MTCLI_PATH) go test -count=1 -race $(INTEGRATION_TESTS)
 
 check: golangci-lint goimports ## Runs all checks.
 	@go fmt $(PKGS) $(INTEGRATION_TESTS)

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -1,21 +1,22 @@
 package validate
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/mt-sre/addon-metadata-operator/pkg/validators"
 
 	"github.com/mt-sre/addon-metadata-operator/pkg/utils"
 )
 
-func Validate(mb utils.MetaBundle) (bool, []error) {
+func Validate(mb utils.MetaBundle, filter *validatorsFilter) (bool, []error) {
 	errs := []error{}
 	allSuccess := true
-	validators := GetAllValidators()
 
 	printMetaHeading()
 
-	for _, validator := range validators {
+	for _, validator := range filter.GetValidators() {
 		fmt.Printf("\r%s\t\t", validator.Description)
 		success, err := validator.Runner(mb)
 		if err != nil {
@@ -32,19 +33,104 @@ func Validate(mb utils.MetaBundle) (bool, []error) {
 	return allSuccess, errs
 }
 
-func GetAllValidators() []utils.Validator {
-	return []utils.Validator{
-		{
-			Description: "Ensure defaultChannel is present in list of channels",
-			Runner:      validators.ValidateDefaultChannel,
-		},
-		{
-			Description: "Ensure `label` to follow the format api.openshift.com/addon-<operator-id>",
-			Runner:      validators.ValidateAddonLabel,
-		},
-		{
-			Description: "Ensure current csv is present in the index image",
-			Runner:      validators.ValidateCSVPresent,
-		},
+// name formatting rule: [0-9]{3}_([a-z]*_?)*
+var AllValidators = map[string]utils.Validator{
+	"001_default_channel": {
+		Description: "Ensure defaultChannel is present in list of channels",
+		Runner:      validators.ValidateDefaultChannel,
+	},
+	"002_label_format": {
+		Description: "Ensure `label` to follow the format api.openshift.com/addon-<operator-id>",
+		Runner:      validators.ValidateAddonLabel,
+	},
+	"003_csv_present": {
+		Description: "Ensure current csv is present in the index image",
+		Runner:      validators.ValidateCSVPresent,
+	},
+}
+
+func getExistingValidatorNames() []string {
+	var res []string
+	for name := range AllValidators {
+		res = append(res, name)
 	}
+	return res
+}
+
+type validatorsFilter struct {
+	AllEnabled     bool
+	ValidatorNames []string
+}
+
+func NewFilter(disabled, enabled string) (*validatorsFilter, error) {
+	// empty filter - all validators are enabled
+	if disabled == "" && enabled == "" {
+		return &validatorsFilter{AllEnabled: true}, nil
+	}
+
+	if err := verifyDisabledEnabled(disabled, enabled); err != nil {
+		return nil, err
+	}
+
+	var validatorNames []string
+	if enabled != "" {
+		validatorNames = strings.Split(enabled, ",")
+	} else {
+		validatorNames = getEnabledValidatorNamesFromDisabled(disabled)
+	}
+
+	return &validatorsFilter{AllEnabled: false, ValidatorNames: validatorNames}, nil
+}
+
+func verifyDisabledEnabled(disabled, enabled string) error {
+	// error: mutually exclusive
+	if disabled != "" && enabled != "" {
+		return errors.New("Can't set both --disabled and --enabled. They are mutually exclusive.")
+	}
+	var rawNames string
+	if enabled != "" {
+		rawNames = enabled
+	} else {
+		rawNames = disabled
+	}
+
+	validNames := strings.Join(getExistingValidatorNames(), ",")
+	for _, name := range strings.Split(rawNames, ",") {
+		if _, ok := AllValidators[name]; !ok {
+			return fmt.Errorf("Could not find validator with name %v. Existing validators are %v.", name, validNames)
+		}
+	}
+	return nil
+}
+
+func getEnabledValidatorNamesFromDisabled(disabled string) []string {
+	var res []string
+
+	allDisabled := make(map[string]bool)
+	for _, disabledName := range strings.Split(disabled, ",") {
+		allDisabled[disabledName] = true
+	}
+
+	for _, name := range getExistingValidatorNames() {
+		if _, ok := allDisabled[name]; !ok {
+			res = append(res, name)
+		}
+	}
+	return res
+}
+
+func (f *validatorsFilter) GetValidators() []utils.Validator {
+	var res []utils.Validator
+	if f.AllEnabled {
+		for _, validator := range AllValidators {
+			res = append(res, validator)
+		}
+	} else {
+		for _, name := range f.ValidatorNames {
+			// no need to track 'ok' as it was already validated by NewFilter func
+			validator := AllValidators[name]
+			res = append(res, validator)
+		}
+	}
+	return res
 }


### PR DESCRIPTION
This is necessary and provides more flexibility when integrating with the managed-tenants pipeline.

We are currently facing an issue where validators are not passing checks, and this is a blocker. As we work on fixing those validators, we can temporarily disable them and keep working on new validators, as well as fixing older ones.

Will also be useful if we ever introduce a bug and somehow need to quickly pass the pipeline.