### PR TITLE
Remove go-playground validate tags.

### DIFF
--- a/api/v1alpha1/addonimageset_types.go
+++ b/api/v1alpha1/addonimageset_types.go
@@ -25,16 +25,16 @@ import (
 type AddonImageSetSpec struct {
 	// +kubebuilder:validation:Required
 	// The name of the imageset along with the version.
-	Name string `json:"name" validate:"required"`
+	Name string `json:"name"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^quay\.io/osd-addons/[a-z-]+`
 	// The url for the index image
-	IndexImage string `json:"indexImage" validate:"required"`
+	IndexImage string `json:"indexImage"`
 
 	// +kubebuilder:validation:Required
 	// A list of image urls of related operators
-	RelatedImages []string `json:"relatedImages" validate:"required"`
+	RelatedImages []string `json:"relatedImages"`
 
 	// +optional
 	// OCM representation of an add-on parameter

--- a/api/v1alpha1/addonmetadata_types.go
+++ b/api/v1alpha1/addonmetadata_types.go
@@ -29,16 +29,16 @@ type AddonMetadataSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^[A-Za-z0-9][A-Za-z0-9-]{0,30}[A-Za-z0-9]$`
 	// Unique ID of the addon
-	ID string `json:"id" validate:"required"`
+	ID string `json:"id"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^[0-9A-Z][A-Za-z0-9-_ ()]+$`
 	// Friendly name for the addon, displayed in the UI
-	Name string `json:"name" validate:"required"`
+	Name string `json:"name"`
 
 	// +kubebuilder:validation:Required
 	// Short description for the addon
-	Description string `json:"description" validate:"required"`
+	Description string `json:"description"`
 
 	// +optional
 	// +kubebuilder:validation:Pattern=`^http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+$`
@@ -47,66 +47,66 @@ type AddonMetadataSpec struct {
 
 	// +kubebuilder:validation:Required
 	// Icon to be shown in UI. Should be around 200px and base64 encoded.
-	Icon string `json:"icon" validate:"required"`
+	Icon string `json:"icon"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^api\.openshift\.com/addon-[0-9a-z][0-9a-z-]{0,30}[0-9a-z]$`
 	// Kubernetes label for the addon. Needs to match: 'api.openshift.com/<addon-id>'.
-	Label string `json:"label" validate:"required"`
+	Label string `json:"label"`
 
 	// +kubebuilder:validation:Required
 	// Set to true to allow installation of the addon.
-	Enabled bool `json:"enabled" validate:"required"`
+	Enabled bool `json:"enabled"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^([A-Za-z -]+ <[0-9A-Za-z_.-]+@redhat\.com>,?)+$`
 	// Team or individual responsible for this addon. Needs to match: 'some name <some-email@redhat.com>'.
-	AddonOwner string `json:"addonOwner" validate:"required"`
+	AddonOwner string `json:"addonOwner"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^quay\.io/osd-addons/[a-z-]+$`
 	// Quay repository for the addon operator. Needs to match: 'quay.io/osd-addons/<my-addon-repo>'.
-	QuayRepo string `json:"quayRepo" validate:"required"`
+	QuayRepo string `json:"quayRepo"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^quay\.io/[0-9A-Za-z._-]+/[0-9A-Za-z._-]+(:[A-Za-z0-9._-]+)?$`
 	// Quay repository for the testHarness image. Needs to match: 'quay.io/<my-repo>/<my-test-harness>:<my-tag>'.
-	TestHarness string `json:"testHarness" validate:"required"`
+	TestHarness string `json:"testHarness"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum={AllNamespaces,SingleNamespace,OwnNamespace}
 	// OLM InstallMode for the addon operator. One of: AllNamespaces, SingleNamespace or OwnNamespace.
-	InstallMode string `json:"installMode" validate:"required"`
+	InstallMode string `json:"installMode"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^[A-Za-z0-9][A-Za-z0-9-]{0,60}[A-Za-z0-9]$`
 	// Namespace where the addon operator should be installed.
-	TargetNamespace string `json:"targetNamespace" validate:"required"`
+	TargetNamespace string `json:"targetNamespace"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:UniqueItems=true
 	// Namespaces managed by the addon-operator. Need to include the TargetNamespace.
-	Namespaces []string `json:"namespaces" validate:"required"`
+	Namespaces []string `json:"namespaces"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^[A-Za-z0-9][A-Za-z0-9-_]{0,35}[A-Za-z0-9]$`
 	// Refers to the SKU name for the addon.
-	OcmQuotaName string `json:"ocmQuotaName" validate:"required"`
+	OcmQuotaName string `json:"ocmQuotaName"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=0
 	// TODO: what is this?
-	OcmQuotaCost int `json:"ocmQuotaCost" validate:"required"`
+	OcmQuotaCost int `json:"ocmQuotaCost"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^[A-Za-z0-9][A-Za-z0-9-]{0,30}[A-Za-z0-9]$`
 	// Name of the addon operator.
-	OperatorName string `json:"operatorName" validate:"required"`
+	OperatorName string `json:"operatorName"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum={alpha,beta,stable,edge,rc}
 	// OLM channel from which to install the addon-operator. One of: alpha, beta, stable, edge or rc.
-	DefaultChannel string `json:"defaultChannel" validate:"required"`
+	DefaultChannel string `json:"defaultChannel"`
 
 	// +optional
 	// Deprecated: List of channels where the addon operator is available.
@@ -116,12 +116,12 @@ type AddonMetadataSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:default:{}
 	// Labels to be applied on all listed namespaces.
-	NamespaceLabels map[string]string `json:"namespaceLabels" validate:"required"`
+	NamespaceLabels map[string]string `json:"namespaceLabels"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:default:{}
 	// Annotations to be applied on all listed namespaces.
-	NamespaceAnnotations map[string]string `json:"namespaceAnnotations" validate:"required"`
+	NamespaceAnnotations map[string]string `json:"namespaceAnnotations"`
 
 	// +optional
 	// +kubebuilder:validation:Pattern=`^quay\.io/osd-addons/[a-z-]+`
@@ -204,7 +204,7 @@ type AddonMetadata struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   AddonMetadataSpec   `json:"spec,omitempty" validate:"required"`
+	Spec   AddonMetadataSpec   `json:"spec,omitempty"`
 	Status AddonMetadataStatus `json:"status,omitempty"`
 }
 

--- a/docs/types.md
+++ b/docs/types.md
@@ -19,12 +19,3 @@ The use of pointers is required for optional fields so we can distinguish betwee
 | `int`      | `*int`        |
 | `<struct>` | `*<struct>`   |
 | `[]<type>` | `*[]<type>`   |
-
-
-## Go validator guideline
-
-Make sure to add a `validate:"<validation>"` tag to all fields as a recursive tag-base validator runs as part of the validation framework.
-
-Make sure to add the `required` on required fields.
-
-View the full list of [Baked-in Validations](https://github.com/go-playground/validator#baked-in-validations).

--- a/pkg/mtsre/v1/addons.go
+++ b/pkg/mtsre/v1/addons.go
@@ -23,13 +23,13 @@ type Notification string
 //+kubebuilder:object:generate=true
 type Monitoring struct {
 	// +kubebuilder:validation:Required
-	Namespace string `json:"namespace" validate:"required"`
+	Namespace string `json:"namespace"`
 
 	// +kubebuilder:validation:Required
-	MatchNames []string `json:"matchNames" validate:"required"`
+	MatchNames []string `json:"matchNames"`
 
 	// +kubebuilder:validation:Required
-	MatchLabels map[string]string `json:"matchLabels" validate:"required"`
+	MatchLabels map[string]string `json:"matchLabels"`
 }
 
 //+kubebuilder:object:generate=true
@@ -59,23 +59,23 @@ type BundleParameters struct {
 type PagerDuty struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^[A-Za-z0-9]+$`
-	EscalationPolicy string `json:"snitchNamePostFix" validate:"required"`
+	EscalationPolicy string `json:"snitchNamePostFix"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=0
-	AcknowledgeTimeout int `json:"acknowledgeTimeout" validate:"required"`
+	AcknowledgeTimeout int `json:"acknowledgeTimeout"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=0
-	ResolveTimeout int `json:"resolveTimeout" validate:"required"`
+	ResolveTimeout int `json:"resolveTimeout"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^[A-Za-z0-9][A-Za-z0-9-]{0,60}[A-Za-z0-9]$`
-	SecretName string `json:"secretName" validate:"required"`
+	SecretName string `json:"secretName"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^[A-Za-z0-9][A-Za-z0-9-]{0,60}[A-Za-z0-9]$`
-	SecretNamespace string `json:"secretNamespace" validate:"required"`
+	SecretNamespace string `json:"secretNamespace"`
 }
 
 //+kubebuilder:object:generate=true
@@ -90,7 +90,7 @@ type DeadmansSnitch struct {
 	TargetSecretRef *TargetSecretRef `json:"targetSecretRef"`
 
 	// +kubebuilder:validation:Required
-	Tags []Tag `json:"tags" validate:"required"`
+	Tags []Tag `json:"tags"`
 }
 
 // +kubebuilder:validation:Pattern=`^[A-Za-z0-9][A-Za-z0-9-]{0,60}[A-Za-z0-9]$`
@@ -110,14 +110,14 @@ type TargetSecretRef struct {
 //+kubebuilder:object:generate=true
 type SubscriptionConfig struct {
 	// +kubebuilder:validation:Required
-	Env *[]EnvItem `json:"env" validate:"required"`
+	Env *[]EnvItem `json:"env"`
 }
 
 //+kubebuilder:object:generate=true
 type EnvItem struct {
 	// +kubebuilder:validation:Required
-	Name string `json:"name" validate:"required"`
+	Name string `json:"name"`
 
 	// +kubebuilder:validation:Required
-	Value string `json:"value" validate:"required"`
+	Value string `json:"value"`
 }

--- a/pkg/ocm/v1/addons.go
+++ b/pkg/ocm/v1/addons.go
@@ -21,27 +21,27 @@ Update zz_generated.deepcopy.go with:
 //+kubebuilder:object:generate=true
 type AddOnParameter struct {
 	// +kubebuilder:validation:Required
-	ID string `json:"id" validate:"required"`
+	ID string `json:"id"`
 
 	// +kubebuilder:validation:Required
-	Name string `json:"name" validate:"required"`
+	Name string `json:"name"`
 
 	// +kubebuilder:validation:Required
-	Description string `json:"description" validate:"required"`
+	Description string `json:"description"`
 
 	// +kubebuilder:validation:Required
-	ValueType AddOnParameterValueType `json:"value_type" validate:"required"`
+	ValueType AddOnParameterValueType `json:"value_type"`
 
 	// +optional
 	Validation *string `json:"validation"`
 	// +kubebuilder:validation:Required
-	Required bool `json:"required" validate:"required"`
+	Required bool `json:"required"`
 
 	// +kubebuilder:validation:Required
-	Editable bool `json:"editable" validate:"required"`
+	Editable bool `json:"editable"`
 
 	// +kubebuilder:validation:Required
-	Enabled bool `json:"enabled" validate:"required"`
+	Enabled bool `json:"enabled"`
 
 	// +optional
 	DefaultValue *string `json:"default_value"`
@@ -69,19 +69,19 @@ const (
 //+kubebuilder:object:generate=true
 type AddOnParameterOption struct {
 	// +kubebuilder:validation:Required
-	Name string `json:"name" validate:"required"`
+	Name string `json:"name"`
 
 	// +kubebuilder:validation:Required
-	Value string `json:"value" validate:"required"`
+	Value string `json:"value"`
 }
 
 //+kubebuilder:object:generate=true
 type AddOnResourceRequirement struct {
 	// +kubebuilder:validation:Required
-	Resource AddOnRequirementResourceType `json:"resource" validate:"required"`
+	Resource AddOnRequirementResourceType `json:"resource"`
 
 	// +kubebuilder:validation:Required
-	Data AddOnRequirementData `json:"data" validate:"required"`
+	Data AddOnRequirementData `json:"data"`
 
 	// +optional
 	Status *AddOnResourceRequirementStatus `json:"status"`
@@ -109,29 +109,29 @@ const (
 //+kubebuilder:object:generate=true
 type AddOnRequirement struct {
 	// +kubebuilder:validation:Required
-	ID string `json:"id" validate:"required"`
+	ID string `json:"id"`
 
 	// +kubebuilder:validation:Required
-	Resource AddOnRequirementResourceType `json:"resource" validate:"required"`
+	Resource AddOnRequirementResourceType `json:"resource"`
 
 	// +kubebuilder:validation:Required
-	Data AddOnRequirementData `json:"data" validate:"required"`
+	Data AddOnRequirementData `json:"data"`
 
 	// +optional
 	Status *AddOnResourceRequirementStatus `json:"status"`
 
 	// +kubebuilder:validation:Required
-	Enabled bool `json:"enabled" validate:"required"`
+	Enabled bool `json:"enabled"`
 }
 
 //+kubebuilder:object:generate=true
 type AddOnSubOperator struct {
 	// +kubebuilder:validation:Required
-	OperatorName string `json:"operator_name" validate:"required"`
+	OperatorName string `json:"operator_name"`
 
 	// +kubebuilder:validation:Required
-	OperatorNamespace string `json:"operator_namespace" validate:"required"`
+	OperatorNamespace string `json:"operator_namespace"`
 
 	// +kubebuilder:validation:Required
-	Enabled bool `json:"enabled" validate:"required"`
+	Enabled bool `json:"enabled"`
 }


### PR DESCRIPTION
I think it doesn't make sense to use the go-playground framework anymore.

It is simpler to write well defined validators to enforce field-level validation, than to write a function, and add a shady tag to a type description. The user experience for our tenants is better with validators as they will provide extensive documentation in their wikis.