### PR TITLE
New output formatting for ValidateCLI.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d // indirect
+	github.com/alexeyco/simpletable v1.0.0
 	github.com/bshuster-repo/logrus-logstash-hook v1.0.2 // indirect
 	github.com/fatih/color v1.13.0
 	github.com/operator-framework/operator-registry v1.19.1

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
+github.com/alexeyco/simpletable v1.0.0 h1:ZQ+LvJ4bmoeHb+dclF64d0LX+7QAi7awsfCrptZrpHk=
+github.com/alexeyco/simpletable v1.0.0/go.mod h1:VJWVTtGUnW7EKbMRH8cE13SigKGx/1fO2SeeOiGeBkk=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -508,6 +510,8 @@ github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.12 h1:Y41i/hVW3Pgwr8gV+J23B9YEY0zxjptBuCWEaxmAOow=
+github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-sqlite3 v1.10.0 h1:jbhqpg7tQe4SupckyijYiy0mJJ/pRyHvXf7JdWK860o=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -648,6 +652,8 @@ github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3x
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/rivo/uniseg v0.1.0 h1:+2KBaVoUmb9XzDsrx/Ct0W/EYOSFf/nWTauy++DprtY=
+github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -79,7 +79,7 @@ func validateMain(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	success, errs := validate.Validate(*metaBundle, filter)
+	success, errs := validate.ValidateCLI(*metaBundle, filter)
 	if len(errs) > 0 {
 		utils.PrintValidationErrors(errs)
 		os.Exit(1)

--- a/pkg/validate/print.go
+++ b/pkg/validate/print.go
@@ -1,32 +1,49 @@
 package validate
 
 import (
-	"fmt"
-	"strings"
-
+	"github.com/alexeyco/simpletable"
 	"github.com/mt-sre/addon-metadata-operator/pkg/utils"
 )
 
 var (
-	equalLines = strings.Repeat("=", 6)
-
-	success = utils.Green("Success")
-	failed  = utils.Red("Failed")
-	err     = utils.IntenselyBoldRed("Error")
+	statusSuccess = utils.Green("Success")
+	statusFailed  = utils.Red("Failed")
+	statusError   = utils.IntenselyBoldRed("Error")
 )
 
-func printMetaHeading() {
-	fmt.Printf("\n%sRUNNING METADATA VALIDATORS%s\n\n", equalLines, equalLines)
+func getTableHeaders() *simpletable.Header {
+	return &simpletable.Header{
+		Cells: []*simpletable.Cell{
+			{Align: simpletable.AlignCenter, Text: "STATUS"},
+			{Align: simpletable.AlignCenter, Text: "CODE"},
+			{Align: simpletable.AlignCenter, Text: "NAME"},
+			{Align: simpletable.AlignCenter, Text: "DESCRIPTION"},
+			{Align: simpletable.AlignCenter, Text: "FAILURE MESSAGE"},
+		},
+	}
 }
 
-func printSuccessMessage(msg string) {
-	fmt.Printf("\r%s\t\t%s", msg, success)
+func newSuccessTableRow(v utils.Validator) []*simpletable.Cell {
+	return newTableRow(v, statusSuccess, "")
 }
 
-func printFailureMessage(msg string) {
-	fmt.Printf("\r%s\t\t%s", msg, failed)
+func newFailedTableRow(v utils.Validator, failureMsg string) []*simpletable.Cell {
+	return newTableRow(v, statusFailed, failureMsg)
 }
 
-func printErrorMessage(msg string) {
-	fmt.Printf("\r%s\t\t%s", msg, err)
+func newErrorTableRow(v utils.Validator, err error) []*simpletable.Cell {
+	return newTableRow(v, statusError, err.Error())
+}
+
+func newTableRow(v utils.Validator, status, failureMsg string) []*simpletable.Cell {
+	if failureMsg == "" {
+		failureMsg = "None"
+	}
+	return []*simpletable.Cell{
+		{Align: simpletable.AlignLeft, Text: status},
+		{Align: simpletable.AlignLeft, Text: v.Code},
+		{Align: simpletable.AlignLeft, Text: v.Name},
+		{Align: simpletable.AlignLeft, Text: v.Description},
+		{Align: simpletable.AlignLeft, Text: failureMsg},
+	}
 }

--- a/pkg/validators/am0002_addon_label.go
+++ b/pkg/validators/am0002_addon_label.go
@@ -13,13 +13,11 @@ func init() {
 var AM0002 = utils.Validator{
 	Code:        "AM0002",
 	Name:        "label_format",
-	Description: "Ensure defaultChannel is present in list of channels",
-	Runner:      ValidateAddonLabel,
+	Description: "Validates whether label follows the format 'api.openshift.com/addon-<id>'",
+	Runner:      validateAddonLabel,
 }
 
-// ValidateAddonLabel validates whether the 'label' field under an addon.yaml follows the format 'api.openshift.com/addon-<id>'
-// TODO - remove this validator once we do field level validation
-func ValidateAddonLabel(metabundle utils.MetaBundle) (bool, string, error) {
+func validateAddonLabel(metabundle utils.MetaBundle) (bool, string, error) {
 	operatorId, label := metabundle.AddonMeta.ID, metabundle.AddonMeta.Label
 	if label != "api.openshift.com/addon-"+operatorId {
 		return false, fmt.Sprintf("addon label '%s' wasn't recognized to follow the 'api.openshift.com/addon-<id>' format", label), nil


### PR DESCRIPTION
Using new fields in the Validator struct to provide better validation output.

Advertise the new wiki: https://github.com/mt-sre/addon-metadata-operator/wiki/<code>

Fix output breaking with inconsistent tabs.

Example of new output:

```bash
$ go run cmd/mtcli/main.go validate ../managed-tenants/addons/reference-addon
```
![image](https://user-images.githubusercontent.com/20143605/147494218-b3e1e144-c968-4e82-9621-ecc65eae03dd.png)
