### PR TITLE
Fix broken build error.

### DIFF
--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -2,7 +2,6 @@ package testutils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -13,33 +12,15 @@ import (
 )
 
 var (
-	RootDir             string = getAndValidateRootDir()
+	RootDir             string = getRootDir()
 	TestdataDir         string = path.Join(RootDir, "internal", "testdata")
 	AddonsImagesetDir   string = path.Join(TestdataDir, "addons-imageset")
 	AddonsIndexImageDir string = path.Join(TestdataDir, "addons-indeximage")
 )
 
-func getAndValidateRootDir() string {
+func getRootDir() string {
 	_, b, _, _ := runtime.Caller(0)
-	root := path.Join(filepath.Dir(b), "..", "..")
-
-	if !dirContainsGoMod(root) {
-		log.Fatal("could not find go.mod in root directory: ", root)
-	}
-	return root
-}
-
-func dirContainsGoMod(root string) bool {
-	files, err := ioutil.ReadDir(root)
-	if err != nil {
-		log.Fatal("can't read root directory, got: ", err)
-	}
-	for _, file := range files {
-		if file.Name() == "go.mod" {
-			return true
-		}
-	}
-	return false
+	return path.Join(filepath.Dir(b), "..", "..")
 }
 
 func RemoveDir(downloadDir string) {

--- a/internal/testutils/testutils_test.go
+++ b/internal/testutils/testutils_test.go
@@ -1,0 +1,22 @@
+package testutils
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateRootDirContainsGoMod(t *testing.T) {
+	files, err := ioutil.ReadDir(RootDir)
+	require.NoError(t, err)
+
+	foundGoMod := false
+	for _, file := range files {
+		if file.Name() == "go.mod" {
+			foundGoMod = true
+			break
+		}
+	}
+	require.True(t, foundGoMod)
+}


### PR DESCRIPTION
Removing a `log.Fatal(...)` that gets executed at every runtime since the `RootDir` var is initialized.

Moving the validation to a test should fix the current build error:

```bash
$ /tmp/mtcli-0.7.0 version
2022/01/03 10:58:39 can't read root directory, got: open /addon-metadata-operator: no such file or directory
exit 1
```