### PR TITLE
[MTSRE-384] IndexExtractor for both sql-based and file-based catalog

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,8 @@ builds:
   - env:
       - CGO_ENABLED=1
       - GO111MODULE=on
+      # required by opm to extract sql-based catalog
+      - CGO_CFLAGS=-DSQLITE_ENABLE_JSON1
     goos:
       - linux
     goarch:

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ E2E_MTCLI_PATH := $(CACHE)/mtcli
 
 # make prow to NOT expect this project to have vendoring
 GOFLAGS=
+# required by opm to extract sql-based catalog
+export CGO_CFLAGS := -DSQLITE_ENABLE_JSON1
 
 all: build
 

--- a/pkg/extractor/index.go
+++ b/pkg/extractor/index.go
@@ -1,0 +1,66 @@
+package extractor
+
+import (
+	"context"
+	"sort"
+
+	"github.com/operator-framework/operator-registry/alpha/action"
+	"github.com/operator-framework/operator-registry/alpha/model"
+)
+
+// allBundlesKey - special cacheKey that means "list all bundles for all packages in the indexImage"
+const allBundlesKey = "__ALL__"
+
+type indexExtractor struct {
+	IndexExtractorCache
+}
+
+func NewIndexExtractor(cache IndexExtractorCache) IndexExtractor {
+	return &indexExtractor{cache}
+}
+
+// ListBundlesFromPackage - returns a sorted list of bundles for a given pkg
+func (i *indexExtractor) ListBundlesFromPackage(indexImage string, pkgName string) ([]string, error) {
+	return i.listBundlesWithCache(indexImage, pkgName)
+}
+
+// ListAllBundles - returns a sorted list of all bundles for all pkgs
+func (i *indexExtractor) ListAllBundles(indexImage string) ([]string, error) {
+	return i.listBundlesWithCache(indexImage, allBundlesKey)
+}
+
+// listBundles - return a list of all bundle images, sorted
+func (i *indexExtractor) listBundlesWithCache(indexImage string, cacheKey string) ([]string, error) {
+	if bundles := i.GetBundles(indexImage, cacheKey); bundles != nil {
+		return bundles, nil
+	}
+	pkgName := pkgNameFromCacheKey(cacheKey)
+	lb := action.ListBundles{IndexReference: indexImage, PackageName: pkgName}
+	data, err := lb.Run(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return i.extractAndCache(indexImage, cacheKey, data.Bundles), nil
+}
+
+func pkgNameFromCacheKey(cacheKey string) string {
+	if cacheKey == allBundlesKey {
+		// a pkg name of "" will list all bundles in an indexImage
+		return ""
+	}
+	return cacheKey
+}
+
+func (i *indexExtractor) extractAndCache(indexImage string, cacheKey string, bundles []model.Bundle) []string {
+	var res []string
+	pkgBundlesMap := make(map[string][]string)
+	for _, b := range bundles {
+		if cacheKey == allBundlesKey || b.Package.Name == cacheKey {
+			pkgBundlesMap[b.Package.Name] = append(pkgBundlesMap[b.Package.Name], b.Image)
+		}
+		res = append(res, b.Image)
+	}
+	i.SetBundles(indexImage, pkgBundlesMap)
+	sort.Strings(res)
+	return res
+}

--- a/pkg/extractor/index_cache.go
+++ b/pkg/extractor/index_cache.go
@@ -1,0 +1,47 @@
+package extractor
+
+import (
+	"sort"
+	"sync"
+)
+
+type indexMemoryCache struct {
+	sync.RWMutex
+	store map[string]map[string][]string
+}
+
+// Simple in-memory cache to avoid extracting indexImages twice
+// Indexes first by indexImage, then by packageName
+func NewIndexMemoryCache() IndexExtractorCache {
+	return &indexMemoryCache{store: make(map[string]map[string][]string)}
+}
+
+func (c *indexMemoryCache) GetBundles(indexImage string, cacheKey string) []string {
+	c.RLock()
+	defer c.RUnlock()
+	var res []string
+	if data, ok := c.store[indexImage]; ok {
+		for pkgName, bundles := range data {
+			if cacheKey == allBundlesKey || pkgName == cacheKey {
+				res = append(res, bundles...)
+			}
+		}
+	}
+	if len(res) == 0 {
+		return nil
+	}
+	sort.Strings(res)
+	return res
+}
+
+func (c *indexMemoryCache) SetBundles(indexImage string, pkgBundlesMap map[string][]string) {
+	c.Lock()
+	defer c.Unlock()
+	if _, ok := c.store[indexImage]; ok {
+		for pkgName, bundles := range pkgBundlesMap {
+			c.store[indexImage][pkgName] = bundles
+		}
+	} else {
+		c.store[indexImage] = pkgBundlesMap
+	}
+}

--- a/pkg/extractor/index_test.go
+++ b/pkg/extractor/index_test.go
@@ -1,0 +1,100 @@
+package extractor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIndexExtractorFileBasedAndSQLCatalogs(t *testing.T) {
+	cases := []struct {
+		indexImage      string
+		pkgName         string
+		expectedBundles []string
+	}{
+		{
+			// sql-based catalog image
+			indexImage: "quay.io/osd-addons/reference-addon-index@sha256:b9e87a598e7fd6afb4bfedb31e4098435c2105cc8ebe33231c341e515ba9054d",
+			pkgName:    "reference-addon",
+			expectedBundles: []string{
+				"quay.io/osd-addons/reference-addon-bundle:0.1.0-c15cedb",
+				"quay.io/osd-addons/reference-addon-bundle:0.1.1-c15cedb",
+				"quay.io/osd-addons/reference-addon-bundle:0.1.2-c15cedb",
+				"quay.io/osd-addons/reference-addon-bundle:0.1.3-c15cedb",
+				"quay.io/osd-addons/reference-addon-bundle:0.1.4-c15cedb",
+				"quay.io/osd-addons/reference-addon-bundle:0.1.5-c15cedb",
+			},
+		},
+		{
+			// file-based catalog image
+			indexImage: "quay.io/sblaisdo/reference-addon-index:test",
+			pkgName:    "reference-addon",
+			expectedBundles: []string{
+				"quay.io/osd-addons/reference-addon-bundle:0.1.0-bcb6192",
+				"quay.io/osd-addons/reference-addon-bundle:0.1.1-bcb6192",
+				"quay.io/osd-addons/reference-addon-bundle:0.1.2-bcb6192",
+				"quay.io/osd-addons/reference-addon-bundle:0.1.3-bcb6192",
+				"quay.io/osd-addons/reference-addon-bundle:0.1.4-bcb6192",
+				"quay.io/osd-addons/reference-addon-bundle:0.1.5-bcb6192",
+				"quay.io/osd-addons/reference-addon-bundle:0.1.6-bcb6192",
+			},
+		},
+	}
+	cache := NewIndexMemoryCache()
+	extractor := NewIndexExtractor(cache)
+	for _, tc := range cases {
+		tc := tc // pin
+		t.Run(tc.indexImage, func(t *testing.T) {
+			t.Parallel()
+			bundles, err := extractor.ListBundlesFromPackage(tc.indexImage, tc.pkgName)
+			require.NoError(t, err)
+			require.Equal(t, bundles, tc.expectedBundles)
+			cachedBundles := cache.GetBundles(tc.indexImage, tc.pkgName)
+			require.Equal(t, cachedBundles, tc.expectedBundles)
+		})
+	}
+}
+
+// quay.io/osd-addons/gpu-operator-index@sha256:62e0f330276375758f875c62c90e6c3e4e217247f221c96ce5e4ab64f6617e38
+func TestIndexExtractorListAllBundles(t *testing.T) {
+	t.Parallel()
+	indexImage := "quay.io/osd-addons/gpu-operator-index@sha256:62e0f330276375758f875c62c90e6c3e4e217247f221c96ce5e4ab64f6617e38"
+	pkgBundlesMap := map[string][]string{
+		"gpu-operator-certified-addon": {
+			"quay.io/osd-addons/gpu-operator-bundle:1.7.1-0ddc381",
+			"quay.io/osd-addons/gpu-operator-bundle:1.8.0-0ddc381",
+			"quay.io/osd-addons/gpu-operator-bundle:1.8.2-0ddc381",
+			"quay.io/osd-addons/gpu-operator-bundle:1.8.3-0ddc381",
+			"quay.io/osd-addons/gpu-operator-bundle:1.9.0-beta-0ddc381",
+		},
+		"node-feature-discovery-operator": {
+			"quay.io/osd-addons/gpu-operator-nfd-operator-bundle:4.8.0-0ddc381",
+		},
+	}
+	expectedAllBundles := []string{
+		"quay.io/osd-addons/gpu-operator-bundle:1.7.1-0ddc381",
+		"quay.io/osd-addons/gpu-operator-bundle:1.8.0-0ddc381",
+		"quay.io/osd-addons/gpu-operator-bundle:1.8.2-0ddc381",
+		"quay.io/osd-addons/gpu-operator-bundle:1.8.3-0ddc381",
+		"quay.io/osd-addons/gpu-operator-bundle:1.9.0-beta-0ddc381",
+		"quay.io/osd-addons/gpu-operator-nfd-operator-bundle:4.8.0-0ddc381",
+	}
+	cache := NewIndexMemoryCache()
+	extractor := NewIndexExtractor(cache)
+
+	// test bundles for all packages are listed
+	bundles, err := extractor.ListAllBundles(indexImage)
+	require.NoError(t, err)
+	require.Equal(t, bundles, expectedAllBundles)
+	allCachedBundles := cache.GetBundles(indexImage, allBundlesKey)
+	require.Equal(t, allCachedBundles, expectedAllBundles)
+
+	// test bundles have been cached per pkgName
+	for pkgName, expectedBundles := range pkgBundlesMap {
+		bundles, err := extractor.ListBundlesFromPackage(indexImage, pkgName)
+		require.NoError(t, err)
+		require.Equal(t, bundles, expectedBundles)
+		cachedBundles := cache.GetBundles(indexImage, pkgName)
+		require.Equal(t, cachedBundles, expectedBundles)
+	}
+}

--- a/pkg/extractor/models.go
+++ b/pkg/extractor/models.go
@@ -1,0 +1,11 @@
+package extractor
+
+type IndexExtractor interface {
+	ListBundlesFromPackage(indexImage string, pkgName string) ([]string, error)
+	ListAllBundles(indexImage string) ([]string, error)
+}
+
+type IndexExtractorCache interface {
+	GetBundles(indexImage string, cacheKey string) []string
+	SetBundles(indexImage string, pkgBundlesMap map[string][]string)
+}


### PR DESCRIPTION
To be merged after #45 as it relies on types being in their own package.

An interesting thing is that we need to add `export CGO_CFLAGS="-DSQLITE_ENABLE_JSON1"` as otherwise `go-sqlite3` is built without the JSON extension, and we get cryptic errors when working with sql-based catalog:

```bash
populate channels: no such function: json_object
```