### PR TITLE
Registry does not need to be concurrent safe.

### DIFF
--- a/pkg/validators/registry.go
+++ b/pkg/validators/registry.go
@@ -2,46 +2,38 @@ package validators
 
 import (
 	"log"
-	"sync"
 
 	"github.com/mt-sre/addon-metadata-operator/pkg/types"
 )
 
 // Registry - holds all registered Validators
-var Registry = NewDefaultRegistry()
+var Registry = NewValidatorsRegistry()
 
-func NewDefaultRegistry() defaultRegistry {
-	return defaultRegistry{
-		&sync.Mutex{},
-		make(map[string]types.Validator),
-	}
+func NewValidatorsRegistry() defaultRegistry {
+	return defaultRegistry{Data: make(map[string]types.Validator)}
 }
 
 type defaultRegistry struct {
-	*sync.Mutex
 	Data map[string]types.Validator
 }
 
 // Add - update the registry in a thread-safe way. Called in init() functions
 func (r *defaultRegistry) Add(v types.Validator) {
-	r.Lock()
-	defer r.Unlock()
-
 	if _, ok := r.Data[v.Code]; ok {
-		log.Fatalf("Validator code %v already exist.", v.Code)
+		log.Panicf("Validator code %v already exist.", v.Code)
 	}
 	r.Data[v.Code] = v
 }
 
-func (r defaultRegistry) Len() int {
+func (r *defaultRegistry) Len() int {
 	return len(r.Data)
 }
 
-func (r defaultRegistry) All() map[string]types.Validator {
+func (r *defaultRegistry) All() map[string]types.Validator {
 	return r.Data
 }
 
-func (r defaultRegistry) Get(k string) (types.Validator, bool) {
+func (r *defaultRegistry) Get(k string) (types.Validator, bool) {
 	v, ok := r.Data[k]
 	return v, ok
 }

--- a/pkg/validators/registry_test.go
+++ b/pkg/validators/registry_test.go
@@ -1,0 +1,45 @@
+package validators
+
+import (
+	"testing"
+
+	"github.com/mt-sre/addon-metadata-operator/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistryPanicsDuplicateKey(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		require.NotNil(t, recover())
+	}()
+
+	registry := NewValidatorsRegistry()
+	allValidators := []types.Validator{
+		{Code: "TEST0001"},
+		{Code: "TEST0001"},
+	}
+	for _, v := range allValidators {
+		registry.Add(v)
+	}
+}
+
+func TestRegistryNonConcurrent(t *testing.T) {
+	t.Parallel()
+	registry := NewValidatorsRegistry()
+	allValidators := []types.Validator{
+		{Code: "TEST0001"},
+		{Code: "TEST0002"},
+		{Code: "TEST0003"},
+		{Code: "TEST0004"},
+		{Code: "TEST0005"},
+		{Code: "TEST0006"},
+	}
+	require.Equal(t, registry.Len(), 0)
+	for _, v := range allValidators {
+		registry.Add(v)
+		vCopy, ok := registry.Get(v.Code)
+		require.True(t, ok)
+		require.Equal(t, v, vCopy)
+	}
+	require.Equal(t, registry.Len(), len(allValidators))
+}


### PR DESCRIPTION
~~Following a thread in addon-operator: https://github.com/openshift/addon-operator/pull/125#discussion_r781984425~~

~~We should pass mutex by value.~~

Edit: no need for registry to be concurrent safe.