### PR TITLE
[MTSRE-397] adding bypass for tagless images required during on-boarding

### DIFF
--- a/pkg/utils/bundle_utils.go
+++ b/pkg/utils/bundle_utils.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"strings"
 	"sync"
 
 	"github.com/mt-sre/addon-metadata-operator/pkg/types"
@@ -31,6 +32,11 @@ func ExtractAndParseAddons(indexImage, addonIdentifier string) ([]registry.Bundl
 
 	if indexImage == "" {
 		return []registry.Bundle{}, errors.New("Missing index image!")
+	}
+
+	// ignore tagless images used by addons in the process of on-boarding
+	if parts := strings.SplitN(indexImage, ":", 2); len(parts) < 2 {
+		return []registry.Bundle{}, nil
 	}
 
 	indexImageExtractor := DefaultIndexImageExtractor{


### PR DESCRIPTION
Metadata will include a placeholder value for indexImage during on-boarding which is unpullable. This PR includes a guard to bypass image pull and bundle loading in this scenario.