### PR TITLE
[MTSRE-399] Eliminating public package vars in 'testutils'

### DIFF
--- a/internal/testutils/reference_addon.go
+++ b/internal/testutils/reference_addon.go
@@ -31,10 +31,8 @@ type singleton struct {
 }
 
 var (
-	ReferenceAddonImageSetDir   = path.Join(AddonsImagesetDir, "reference-addon")
-	ReferenceAddonIndexImageDir = path.Join(AddonsIndexImageDir, "reference-addon")
-	instance                    *singleton
-	lock                        = sync.Mutex{}
+	instance *singleton
+	lock     = sync.Mutex{}
 )
 
 // GetReferenceAddonStage - uses singleton pattern to avoid loading yaml manifests over and over
@@ -63,11 +61,11 @@ func GetReferenceAddonStage() (*singleton, error) {
 }
 
 func (r *singleton) ImageSetDir() string {
-	return path.Join(AddonsImagesetDir, "reference-addon")
+	return path.Join(AddonsImagesetDir(), "reference-addon")
 }
 
 func (r *singleton) IndexImageDir() string {
-	return path.Join(AddonsIndexImageDir, "reference-addon")
+	return path.Join(AddonsIndexImageDir(), "reference-addon")
 }
 
 func (r *singleton) GetMetadata(useImageSet bool) (*addonsv1alpha1.AddonMetadataSpec, error) {

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -18,16 +18,27 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-var (
-	RootDir             string = getRootDir()
-	TestdataDir         string = path.Join(RootDir, "internal", "testdata")
-	AddonsImagesetDir   string = path.Join(TestdataDir, "addons-imageset")
-	AddonsIndexImageDir string = path.Join(TestdataDir, "addons-indeximage")
-)
+var rootDir string
 
-func getRootDir() string {
+func init() {
 	_, b, _, _ := runtime.Caller(0)
-	return path.Join(filepath.Dir(b), "..", "..")
+	rootDir = path.Join(filepath.Dir(b), "..", "..")
+}
+
+func AddonsIndexImageDir() string {
+	return path.Join(TestdataDir(), "addons-indeximage")
+}
+
+func AddonsImagesetDir() string {
+	return path.Join(TestdataDir(), "addons-imageset")
+}
+
+func TestdataDir() string {
+	return path.Join(RootDir(), "internal", "testdata")
+}
+
+func RootDir() string {
+	return rootDir
 }
 
 func RemoveDir(downloadDir string) {

--- a/internal/testutils/testutils_test.go
+++ b/internal/testutils/testutils_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestValidateRootDirContainsGoMod(t *testing.T) {
-	files, err := ioutil.ReadDir(RootDir)
+	files, err := ioutil.ReadDir(RootDir())
 	require.NoError(t, err)
 
 	foundGoMod := false

--- a/pkg/validators/am0007_test.go
+++ b/pkg/validators/am0007_test.go
@@ -1,6 +1,8 @@
 package validators_test
 
 import (
+	"path"
+
 	"github.com/mt-sre/addon-metadata-operator/api/v1alpha1"
 	"github.com/mt-sre/addon-metadata-operator/internal/testutils"
 	"github.com/mt-sre/addon-metadata-operator/pkg/types"
@@ -23,7 +25,7 @@ func (v TestAM0007) Run(mb types.MetaBundle) types.ValidatorResult {
 }
 
 func (v TestAM0007) SucceedingCandidates() ([]types.MetaBundle, error) {
-	testBundle, err := testutils.NewBundle("random-bundle", "../../internal/testdata/assets/am0007/csv.yaml")
+	testBundle, err := loadAM0007TestBundle()
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +57,7 @@ func (v TestAM0007) SucceedingCandidates() ([]types.MetaBundle, error) {
 }
 
 func (v TestAM0007) FailingCandidates() ([]types.MetaBundle, error) {
-	testBundle, err := testutils.NewBundle("random-bundle", "../../internal/testdata/assets/am0007/csv.yaml")
+	testBundle, err := loadAM0007TestBundle()
 	if err != nil {
 		return nil, err
 	}
@@ -87,4 +89,8 @@ func (v TestAM0007) FailingCandidates() ([]types.MetaBundle, error) {
 		},
 	}
 	return res, nil
+}
+
+func loadAM0007TestBundle() (registry.Bundle, error) {
+	return testutils.NewBundle("random-bundle", path.Join(testutils.TestdataDir(), "assets/am0007/csv.yaml"))
 }


### PR DESCRIPTION
## Summary

Replacing public package vars in `testutils` package with public functions. Also eliminating relative path reference in `am0007_test.go`.

## References
[Background](https://dave.cheney.net/2017/06/11/go-without-package-scoped-variables) on the dangers of global state in golang.