### PR TITLE
[MTSRE-395] mtcli list-validators

### DIFF
--- a/internal/cmd/list_validators.go
+++ b/internal/cmd/list_validators.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alexeyco/simpletable"
+	"github.com/mt-sre/addon-metadata-operator/pkg/types"
+	"github.com/mt-sre/addon-metadata-operator/pkg/validators"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	mtcli.AddCommand(listValidatorsCmd)
+}
+
+var (
+	listValidatorsExamples = []string{
+		"  # List all the registered validators.",
+		"  mtcli list-validators",
+	}
+	listValidatorsCmd = &cobra.Command{
+		Use:     "list-validators",
+		Short:   "List all the registered validators.",
+		Example: strings.Join(listValidatorsExamples, "\n"),
+		Run:     listValidatorsMain,
+	}
+)
+
+func listValidatorsMain(cmd *cobra.Command, args []string) {
+	t := simpletable.New()
+	t.Header = getTableHeaders()
+	for _, v := range validators.Registry.ListSorted() {
+		row := newTableRow(v)
+		t.Body.Cells = append(t.Body.Cells, row)
+	}
+	t.SetStyle(simpletable.StyleCompactLite)
+	fmt.Printf("%v\n\n", t.String())
+}
+
+func getTableHeaders() *simpletable.Header {
+	return &simpletable.Header{
+		Cells: []*simpletable.Cell{
+			{Align: simpletable.AlignCenter, Text: "CODE"},
+			{Align: simpletable.AlignCenter, Text: "NAME"},
+			{Align: simpletable.AlignCenter, Text: "DESCRIPTION"},
+		},
+	}
+}
+
+func newTableRow(v types.Validator) []*simpletable.Cell {
+	return []*simpletable.Cell{
+		{Align: simpletable.AlignLeft, Text: v.Code},
+		{Align: simpletable.AlignLeft, Text: v.Name},
+		{Align: simpletable.AlignLeft, Text: v.Description},
+	}
+}

--- a/pkg/types/validators.go
+++ b/pkg/types/validators.go
@@ -25,6 +25,21 @@ func (v Validator) WithRunner(fn ValidateFunc) Validator {
 	return v
 }
 
+// ValidatorList - implements Sort interface to sort validators per Code
+type ValidatorList []Validator
+
+func (v ValidatorList) Len() int {
+	return len(v)
+}
+
+func (v ValidatorList) Less(i, j int) bool {
+	return v[i].Code < v[j].Code
+}
+
+func (v ValidatorList) Swap(i, j int) {
+	v[i], v[j] = v[j], v[i]
+}
+
 type ValidatorTest interface {
 	Name() string
 	Run(MetaBundle) ValidatorResult

--- a/pkg/types/validators_test.go
+++ b/pkg/types/validators_test.go
@@ -1,0 +1,13 @@
+package types_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/mt-sre/addon-metadata-operator/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidatorListImplementsSort(t *testing.T) {
+	require.Implements(t, (*sort.Interface)(nil), types.ValidatorList{})
+}

--- a/pkg/validators/registry.go
+++ b/pkg/validators/registry.go
@@ -2,6 +2,7 @@ package validators
 
 import (
 	"log"
+	"sort"
 
 	"github.com/mt-sre/addon-metadata-operator/pkg/types"
 )
@@ -9,15 +10,14 @@ import (
 // Registry - holds all registered Validators
 var Registry = NewValidatorsRegistry()
 
-func NewValidatorsRegistry() defaultRegistry {
-	return defaultRegistry{Data: make(map[string]types.Validator)}
+func NewValidatorsRegistry() *defaultRegistry {
+	return &defaultRegistry{Data: make(map[string]types.Validator)}
 }
 
 type defaultRegistry struct {
 	Data map[string]types.Validator
 }
 
-// Add - update the registry in a thread-safe way. Called in init() functions
 func (r *defaultRegistry) Add(v types.Validator) {
 	if _, ok := r.Data[v.Code]; ok {
 		log.Panicf("Validator code %v already exist.", v.Code)
@@ -36,4 +36,13 @@ func (r *defaultRegistry) All() map[string]types.Validator {
 func (r *defaultRegistry) Get(k string) (types.Validator, bool) {
 	v, ok := r.Data[k]
 	return v, ok
+}
+
+func (r *defaultRegistry) ListSorted() types.ValidatorList {
+	res := make(types.ValidatorList, 0)
+	for _, v := range r.Data {
+		res = append(res, v)
+	}
+	sort.Sort(res)
+	return res
 }


### PR DESCRIPTION
This will be useful to compare different releases of `mtcli`, and understand what validators are available.

## Example output

```bash
$ go run cmd/mtcli/main.go list-validators
  CODE            NAME                                            DESCRIPTION
-------- ----------------------- ------------------------------------------------------------------------------
 AM0001   default_channel         Ensure defaultChannel is present in list of channels
 AM0002   label_format            Validates whether label follows the format 'api.openshift.com/addon-<id>'
 AM0004   icon_base64             Ensure that `icon` in Addon metadata is rightfully base64 encoded
 AM0005   test_harness            Ensure that an addon has a valid testharness image
 AM0006   dms_snitchnamepostfix   Ensure `deadmanssnitch.snitchNamePostFix` doesn't begin with 'hive-'
 AM0007   csv_install_modes       Validate installMode is supported.
 AM0008   ensure_namespace        Ensure that the target namespace is listed in the set of channels listed
 AM0009   addon_parameters        Ensure `addOnParameters` section in the addon metadata is rightfully defined
```