### PR TITLE
Extending AM0010 to handle pagerDuty and bundleParameter fields with refactor

### DIFF
--- a/api/v1alpha1/addonmetadata_types.go
+++ b/api/v1alpha1/addonmetadata_types.go
@@ -170,7 +170,8 @@ type AddonMetadataSpec struct {
 	Monitoring *mtsrev1.Monitoring `json:"monitoring"`
 
 	// +optional
-	BundleParameters *mtsrev1.BundleParameters `json:"bundleParameters"`
+	// Deprecated: Replaced by SubscriptionConfig.
+	BundleParameters *mtsrev1.BundleParameters `json:"bundleParameters"` //nolint: staticcheck // ignoring self-deprecation SA1019
 
 	// +optional
 	StartingCSV *string `json:"startingCSV"`

--- a/internal/kube/validation.go
+++ b/internal/kube/validation.go
@@ -1,0 +1,104 @@
+package kube
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/validation"
+	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
+)
+
+// AreValidk8sAnnotationNames validates the given names against the kubernetes
+// format for annotations and returns a slice of validation failure messages
+// if any issues are found. Otherwise an empty slice is returned.
+func AreValidk8sAnnotationNames(names ...string) []string {
+	return areValidk8sNames(IsValidk8sAnnotationName, names...)
+}
+
+// AreValidk8sLabelNames validates the given names against the kubernetes
+// format for labels and returns a slice of validation failure messages
+// if any issues are found. Otherwise an empty slice is returned.
+func AreValidk8sLabelNames(names ...string) []string {
+	return areValidk8sNames(IsValidk8sLabelName, names...)
+}
+
+// AreValidk8sNamespaceNames validates the given names against the kubernetes
+// format for namespaces and returns a slice of validation failure messages
+// if any issues are found. Otherwise an empty slice is returned.
+func AreValidk8sNamespaceNames(names ...string) []string {
+	return areValidk8sNames(IsValidk8sNamespaceName, names...)
+}
+
+func areValidk8sNames(validationFunc func(string) string, names ...string) []string {
+	msgs := make([]string, 0, len(names))
+
+	for _, name := range names {
+		if msg := validationFunc(name); msg != "" {
+			msgs = append(msgs, msg)
+		}
+	}
+
+	return msgs
+}
+
+// IsValidk8sNamespaceName validates the given name against the kubernetes format for
+// namespace names and returns a validation failure message if an issue is found.
+// Otherwise an empty string is returned.
+func IsValidk8sNamespaceName(name string) string {
+	if valid, failureReasons := reasonsToResult(validation.ValidateNamespaceName(name, false)); !valid {
+		return fmt.Sprintf("\"%s\" is not a valid kubernetes namespace name: %s", name, failureReasons)
+	}
+
+	return ""
+}
+
+// IsValidk8sSecretName validates the given name against the kubernetes format for
+// secret names and returns a validation failure message if an issue is found.
+// Otherwise an empty string is returned.
+func IsValidk8sSecretName(name string) string {
+	if valid, failureReasons := reasonsToResult(utilvalidation.IsDNS1123Subdomain(name)); !valid {
+		return fmt.Sprintf("\"%s\" is not a valid kubernetes secret name: %s", name, failureReasons)
+	}
+
+	return ""
+}
+
+// IsValidk8sAnnotationName validates the given name against the kubernetes format for
+// annotation names and returns a validation failure message if an issue is found.
+// Otherwise an empty string is returned.
+func IsValidk8sAnnotationName(name string) string {
+	if msg := isQualifiedk8sName(strings.ToLower(name)); msg != "" {
+		return fmt.Sprintf("\"%s\" is not a valid kubernetes annotation name: %s", name, msg)
+	}
+
+	return ""
+}
+
+// IsValidk8sLabelName validates the given name against the kubernetes format for
+// label names and returns a validation failure message if an issue is found.
+// Otherwise an empty string is returned.
+func IsValidk8sLabelName(name string) string {
+	if msg := isQualifiedk8sName(name); msg != "" {
+		return fmt.Sprintf("\"%s\" is not a valid kubernetes label name: %s", name, msg)
+	}
+
+	return ""
+}
+
+func isQualifiedk8sName(name string) string {
+	if valid, failureReasons := reasonsToResult(utilvalidation.IsQualifiedName(name)); !valid {
+		return failureReasons
+	}
+
+	return ""
+}
+
+func reasonsToResult(reasons []string) (bool, string) {
+	// Handles case where reasons = []string{""} which is
+	// indistinguishable from []string{} when joined
+	if len(reasons) > 0 {
+		return false, strings.Join(reasons, ", ")
+	}
+
+	return true, ""
+}

--- a/pkg/mtsre/v1/addons.go
+++ b/pkg/mtsre/v1/addons.go
@@ -32,6 +32,7 @@ type Monitoring struct {
 	MatchLabels map[string]string `json:"matchLabels" validate:"required"`
 }
 
+// Deprecated: Replaced by SubscriptionConfig.
 //+kubebuilder:object:generate=true
 type BundleParameters struct {
 	// +optional

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/mt-sre/addon-metadata-operator/pkg/types"
 	"github.com/mt-sre/addon-metadata-operator/pkg/validators"
-
-	"github.com/alexeyco/simpletable"
 )
 
 // ValidateCLI - run all validators on a metaBundle struct
@@ -16,24 +14,23 @@ func ValidateCLI(mb types.MetaBundle, filter *validatorsFilter) (bool, []error) 
 	errs := []error{}
 	allSuccess := true
 
-	t := simpletable.New()
-	t.Header = getTableHeaders()
+	table := newResultTable()
 
 	for _, v := range filter.GetValidators() {
-		row := newSuccessTableRow(v)
-		res := validators.CLIMiddlewares(v).Runner(mb)
+		res := validators.CLIMiddlewares(v).Run(mb)
+
+		table.WriteResult(res)
+
 		if res.IsError() {
 			errs = append(errs, res.Error)
-			row = newErrorTableRow(v, res.Error)
 		} else if !res.IsSuccess() {
 			allSuccess = false
-			row = newFailedTableRow(v, res.FailureMsg)
 		}
-		t.Body.Cells = append(t.Body.Cells, row)
 	}
-	t.SetStyle(simpletable.StyleCompactLite)
-	fmt.Printf("%v\n\n", t.String())
+
+	fmt.Printf("%v\n\n", table.String())
 	fmt.Println("Please consult corresponding validator wikis: https://github.com/mt-sre/addon-metadata-operator/wiki/<code>.")
+
 	return allSuccess, errs
 }
 

--- a/pkg/validators/result.go
+++ b/pkg/validators/result.go
@@ -3,18 +3,18 @@ package validators
 import "github.com/mt-sre/addon-metadata-operator/pkg/types"
 
 func Success() types.ValidatorResult {
-	return types.ValidatorResult{Success: true}
+	return types.ValidatorResultSuccess()
 }
 
-func Fail(failureMsg string) types.ValidatorResult {
-	return types.ValidatorResult{Success: false, FailureMsg: failureMsg}
+func Fail(msgs ...string) types.ValidatorResult {
+	return types.ValidatorResultFailure(msgs...)
 }
 
 func Error(err error) types.ValidatorResult {
-	return types.ValidatorResult{Success: false, Error: err, RetryableError: false}
+	return types.ValidatorResultError(err, false)
 }
 
 // RetryableError - used by the Retry middleware to automatically re-run validators
 func RetryableError(err error) types.ValidatorResult {
-	return types.ValidatorResult{Success: false, Error: err, RetryableError: true}
+	return types.ValidatorResultError(err, true)
 }


### PR DESCRIPTION
Several items are addressed in this PR as a follow up to #55:
- Additional k8s resource names were identified in the metadata (`pagerDuty.Secret`, `pagerDuty.SecretNameSpace` and `bundleParameters.AddonParamsSecretname`) and have been added to the scope of AM0010.
- Private helpers of AM0010 have been refactored and repackaged into more appropriate locations.
- The `validate` subcommand has also been enabled to write multiple failures for a single `ValidatorResult`.