### PR TITLE
Csv rbac validations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	golang.org/x/mod v0.4.2
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	gopkg.in/yaml.v2 v2.4.0
+	k8s.io/api v0.22.2
 	k8s.io/apiextensions-apiserver v0.22.2
 	k8s.io/apimachinery v0.22.2
 	k8s.io/client-go v0.22.2

--- a/pkg/types/csv_rbac.go
+++ b/pkg/types/csv_rbac.go
@@ -1,0 +1,263 @@
+package types
+
+import (
+	"fmt"
+	"sort"
+)
+
+type CsvPermissions struct {
+	ClusterPermissions []Permissions `json:"clusterPermissions"`
+	Permissions        []Permissions `json:"permissions"`
+}
+
+type Permissions struct {
+	ServiceAccount string `json:"serviceAccount"`
+	Rules          []Rule `json:"rules"`
+}
+
+type Rule struct {
+	name            string   // used in tests
+	ApiGroups       []string `json:"apiGroups"`
+	Resources       []string `json:"resources"`
+	Verbs           []string `json:"verbs"`
+	ResourceNames   []string `json:"resourceNames"`
+	NonResourceURLs []string `json:"nonResourceURLs"`
+}
+
+type operator string
+
+type permissionType string
+
+type RuleFilter struct {
+	PermissionType           permissionType
+	ApiGroupFilterObj        *FilterObj
+	ResourcesFilterObj       *FilterObj
+	VerbsFilterObj           *FilterObj
+	ResourceNamesFilterObj   *FilterObj
+	NonResourceURLsFilterObj *FilterObj
+}
+
+type FilterObj struct {
+	Args         []string
+	OperatorName operator
+}
+
+type filterFunc func(*Rule, RuleFilter) *Rule
+
+const (
+	apiGroupFilterType        = "apiGroupFilter"
+	resourcesFilterType       = "resourcesFilter"
+	verbsFilterType           = "verbsFilter"
+	resourceNamesFilterType   = "resourceNamesFilter"
+	nonResourceURLsFilterType = "nonResourceURLsFilter"
+)
+
+var (
+	InOperator           operator = "IN"
+	NotInOperator        operator = "NOT_IN"
+	EqualsOperator       operator = "EQUAL"
+	NotEqualOperator     operator = "NOT_EQUAL"
+	ExistsOperator       operator = "EXISTS"
+	DoesNotExistOperator operator = "DOES_NOT_EXIST"
+	AnyOperator          operator = "ANY"
+)
+
+var (
+	AllPermissionType        permissionType = "all"
+	NameSpacedPermissionType permissionType = "namespaced"
+	ClusterPermissionType    permissionType = "clusterScoped"
+)
+
+func genFilter(attrFetcher func(*Rule) []string, filterType string) filterFunc {
+	return func(rule *Rule, filter RuleFilter) *Rule {
+		args := attrFetcher(rule)
+		filterObj := func() *FilterObj {
+			switch filterType {
+			case apiGroupFilterType:
+				return filter.ApiGroupFilterObj
+			case resourcesFilterType:
+				return filter.ResourcesFilterObj
+			case verbsFilterType:
+				return filter.VerbsFilterObj
+			case resourceNamesFilterType:
+				return filter.ResourceNamesFilterObj
+			case nonResourceURLsFilterType:
+				return filter.NonResourceURLsFilterObj
+			default:
+				panic("Unsupported filter type")
+			}
+		}()
+		if eval(args, filterObj) {
+			return rule
+		}
+		// Return nil if the rule doesnt match the filtering condition.
+		return nil
+	}
+}
+
+var (
+	apiGroupFilter = genFilter(
+		func(r *Rule) []string {
+			if r != nil {
+				return r.ApiGroups
+			}
+			return []string{}
+		},
+		apiGroupFilterType,
+	)
+	resourcesFilter = genFilter(
+		func(r *Rule) []string {
+			if r != nil {
+				return r.Resources
+			}
+			return []string{}
+		},
+		resourcesFilterType,
+	)
+	verbsFilter = genFilter(
+		func(r *Rule) []string {
+			if r != nil {
+				return r.Verbs
+			}
+			return []string{}
+		},
+		verbsFilterType,
+	)
+	resourceNamesFilter = genFilter(
+		func(r *Rule) []string {
+			if r != nil {
+				return r.ResourceNames
+			}
+			return []string{}
+		},
+		resourceNamesFilterType,
+	)
+	nonResourceURLsFilter = genFilter(
+		func(r *Rule) []string {
+			if r != nil {
+				return r.NonResourceURLs
+			}
+			return []string{}
+		},
+		nonResourceURLsFilterType,
+	)
+)
+
+// Returns the list of rules matching the filtering conditions
+func (cp CsvPermissions) FilterRules(ruleMatcher RuleFilter) []Rule {
+	concernedPermissionRules := func() []Permissions {
+		switch ruleMatcher.PermissionType {
+		case AllPermissionType:
+			return append(cp.ClusterPermissions, cp.Permissions...)
+		case NameSpacedPermissionType:
+			return cp.Permissions
+		case ClusterPermissionType:
+			return cp.ClusterPermissions
+		default:
+			return []Permissions{}
+		}
+	}()
+	filteredRules := make([]Rule, 0)
+	for _, permissionRule := range concernedPermissionRules {
+		for _, rule := range permissionRule.Rules {
+			res := runFilters(getAllAttributeFilters(), &rule, ruleMatcher)
+			if res != nil {
+				filteredRules = append(filteredRules, rule)
+			}
+		}
+	}
+
+	return filteredRules
+}
+
+func runFilters(filters []filterFunc, rule *Rule, condition RuleFilter) *Rule {
+	if len(filters) == 0 || rule == nil {
+		return rule
+	}
+
+	for _, filter := range filters {
+		res := filter(rule, condition)
+		if res == nil {
+			return nil
+		}
+	}
+	return rule
+}
+
+func getAllAttributeFilters() []filterFunc {
+	return []filterFunc{
+		apiGroupFilter,
+		resourcesFilter,
+		verbsFilter,
+		resourceNamesFilter,
+		nonResourceURLsFilter,
+	}
+}
+
+func includes(items []string, itemsToBePresent []string) bool {
+	itemsMap := sliceToSet(items)
+	for _, item := range itemsToBePresent {
+		if _, ok := itemsMap[item]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	sort.Strings(a)
+	sort.Strings(b)
+
+	for index := range a {
+		if a[index] != b[index] {
+			return false
+		}
+	}
+	return true
+}
+
+// Checks if any element in b is present in a.
+func any(a, b []string) bool {
+	source := sliceToSet(a)
+	for _, item := range b {
+		if _, ok := source[item]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func sliceToSet(items []string) map[string]struct{} {
+	res := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		res[item] = struct{}{}
+	}
+	return res
+}
+
+func eval(ruleArgs []string, filterObj *FilterObj) bool {
+	if filterObj == nil {
+		return true
+	}
+	switch filterObj.OperatorName {
+	case InOperator:
+		return includes(ruleArgs, filterObj.Args)
+	case NotInOperator:
+		return !includes(ruleArgs, filterObj.Args)
+	case EqualsOperator:
+		return equal(ruleArgs, filterObj.Args)
+	case NotEqualOperator:
+		return !equal(ruleArgs, filterObj.Args)
+	case ExistsOperator:
+		return len(ruleArgs) > 0
+	case DoesNotExistOperator:
+		return len(ruleArgs) == 0
+	case AnyOperator:
+		return any(ruleArgs, filterObj.Args)
+	default:
+		panic(fmt.Sprintf("eval: Unsupported operator %s", filterObj.OperatorName))
+	}
+}

--- a/pkg/types/csv_rbac_test.go
+++ b/pkg/types/csv_rbac_test.go
@@ -1,0 +1,190 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterRules(t *testing.T) {
+	inputRbacRules := CsvPermissions{
+		ClusterPermissions: []Permissions{
+			{
+				Rules: []Rule{
+					{
+						name:            "rule-1",
+						ApiGroups:       []string{"api_group_1"},
+						Resources:       []string{"resource_1"},
+						Verbs:           []string{"*"},
+						ResourceNames:   []string{"sample1"},
+						NonResourceURLs: []string{},
+					},
+					{
+						name:            "rule-2",
+						ApiGroups:       []string{"api_group_2", "api_group_3", "api_group_1"},
+						Resources:       []string{"resource_2", "resource_3", "*"},
+						Verbs:           []string{"*"},
+						ResourceNames:   []string{"sample2", "sample3"},
+						NonResourceURLs: []string{},
+					},
+				},
+			},
+		},
+		Permissions: []Permissions{
+			{
+				Rules: []Rule{
+					{
+						name:            "rule-3",
+						ApiGroups:       []string{"api_group_4"},
+						Resources:       []string{"resource_5"},
+						Verbs:           []string{"*"},
+						ResourceNames:   []string{"sample4"},
+						NonResourceURLs: []string{"port-forward"},
+					},
+				},
+			},
+		},
+	}
+	filterCases := []struct {
+		input          RuleFilter
+		expectedOutput []string
+	}{
+		{
+			input: RuleFilter{
+				PermissionType: AllPermissionType,
+				ApiGroupFilterObj: &FilterObj{
+					Args:         []string{"api_group_1"},
+					OperatorName: InOperator,
+				},
+			},
+			expectedOutput: []string{"rule-1", "rule-2"},
+		},
+		{
+			input: RuleFilter{
+				PermissionType: AllPermissionType,
+				ApiGroupFilterObj: &FilterObj{
+					Args:         []string{"api_group_10"},
+					OperatorName: InOperator,
+				},
+			},
+			expectedOutput: []string{},
+		},
+		{
+			input: RuleFilter{
+				PermissionType: AllPermissionType,
+				ApiGroupFilterObj: &FilterObj{
+					Args:         []string{"api_group_1"},
+					OperatorName: NotInOperator,
+				},
+			},
+			expectedOutput: []string{"rule-3"},
+		},
+		{
+			input: RuleFilter{
+				PermissionType: AllPermissionType,
+				ResourceNamesFilterObj: &FilterObj{
+					Args:         []string{"sample1"},
+					OperatorName: InOperator,
+				},
+			},
+			expectedOutput: []string{"rule-1"},
+		},
+		{
+			input: RuleFilter{
+				PermissionType: AllPermissionType,
+				ApiGroupFilterObj: &FilterObj{
+					Args:         []string{"api_group_1"},
+					OperatorName: NotEqualOperator,
+				},
+			},
+			expectedOutput: []string{"rule-2", "rule-3"},
+		},
+		{
+			input: RuleFilter{
+				PermissionType: AllPermissionType,
+				ApiGroupFilterObj: &FilterObj{
+					Args:         []string{"api_group_1", "api_group_3", "api_group_2"},
+					OperatorName: EqualsOperator,
+				},
+			},
+			expectedOutput: []string{"rule-2"},
+		},
+		{
+			input: RuleFilter{
+				PermissionType: AllPermissionType,
+				ApiGroupFilterObj: &FilterObj{
+					Args:         []string{"api_group_1", "api_group_3", "api_group_2"},
+					OperatorName: EqualsOperator,
+				},
+			},
+			expectedOutput: []string{"rule-2"},
+		},
+		{
+			input: RuleFilter{
+				PermissionType: AllPermissionType,
+				NonResourceURLsFilterObj: &FilterObj{
+					Args:         []string{},
+					OperatorName: ExistsOperator,
+				},
+			},
+			expectedOutput: []string{"rule-3"},
+		},
+		{
+			input: RuleFilter{
+				PermissionType: AllPermissionType,
+				NonResourceURLsFilterObj: &FilterObj{
+					Args:         []string{},
+					OperatorName: DoesNotExistOperator,
+				},
+			},
+			expectedOutput: []string{"rule-1", "rule-2"},
+		},
+		{
+			input: RuleFilter{
+				PermissionType: NameSpacedPermissionType,
+				ApiGroupFilterObj: &FilterObj{
+					Args:         []string{"api_group_1"},
+					OperatorName: InOperator,
+				},
+			},
+			expectedOutput: []string{},
+		},
+		{
+			input: RuleFilter{
+				PermissionType: AllPermissionType,
+				ApiGroupFilterObj: &FilterObj{
+					Args:         []string{"api_group_1"},
+					OperatorName: InOperator,
+				},
+				ResourcesFilterObj: &FilterObj{
+					Args:         []string{"*"},
+					OperatorName: InOperator,
+				},
+			},
+			expectedOutput: []string{"rule-2"},
+		},
+		{
+			input: RuleFilter{
+				PermissionType: AllPermissionType,
+				ApiGroupFilterObj: &FilterObj{
+					Args:         []string{"api_group_1"},
+					OperatorName: NotEqualOperator,
+				},
+				VerbsFilterObj: &FilterObj{
+					Args:         []string{"*"},
+					OperatorName: InOperator,
+				},
+			},
+			expectedOutput: []string{"rule-2", "rule-3"},
+		},
+	}
+
+	for _, testCase := range filterCases {
+		res := inputRbacRules.FilterRules(testCase.input)
+		resRuleNames := make([]string, 0)
+		for _, item := range res {
+			resRuleNames = append(resRuleNames, item.name)
+		}
+		require.Equal(t, testCase.expectedOutput, resRuleNames)
+	}
+}

--- a/pkg/types/csv_rbac_test.go
+++ b/pkg/types/csv_rbac_test.go
@@ -3,43 +3,51 @@ package types
 import (
 	"testing"
 
+	rbac "k8s.io/api/rbac/v1"
+
 	"github.com/stretchr/testify/require"
 )
 
 func TestFilterRules(t *testing.T) {
-	inputRbacRules := CsvPermissions{
-		ClusterPermissions: []Permissions{
+	inputRbacRules := CSVPermissions{
+		ClusterPermissions: []Permission{
 			{
 				Rules: []Rule{
 					{
-						name:            "rule-1",
-						ApiGroups:       []string{"api_group_1"},
-						Resources:       []string{"resource_1"},
-						Verbs:           []string{"*"},
-						ResourceNames:   []string{"sample1"},
-						NonResourceURLs: []string{},
+						name: "rule-1",
+						PolicyRule: rbac.PolicyRule{
+							APIGroups:       []string{"api_group_1"},
+							Resources:       []string{"resource_1"},
+							Verbs:           []string{"*"},
+							ResourceNames:   []string{"sample1"},
+							NonResourceURLs: []string{},
+						},
 					},
 					{
-						name:            "rule-2",
-						ApiGroups:       []string{"api_group_2", "api_group_3", "api_group_1"},
-						Resources:       []string{"resource_2", "resource_3", "*"},
-						Verbs:           []string{"*"},
-						ResourceNames:   []string{"sample2", "sample3"},
-						NonResourceURLs: []string{},
+						name: "rule-2",
+						PolicyRule: rbac.PolicyRule{
+							APIGroups:       []string{"api_group_2", "api_group_3", "api_group_1"},
+							Resources:       []string{"resource_2", "resource_3", "*"},
+							Verbs:           []string{"*"},
+							ResourceNames:   []string{"sample2", "sample3"},
+							NonResourceURLs: []string{},
+						},
 					},
 				},
 			},
 		},
-		Permissions: []Permissions{
+		Permissions: []Permission{
 			{
 				Rules: []Rule{
 					{
-						name:            "rule-3",
-						ApiGroups:       []string{"api_group_4"},
-						Resources:       []string{"resource_5"},
-						Verbs:           []string{"*"},
-						ResourceNames:   []string{"sample4"},
-						NonResourceURLs: []string{"port-forward"},
+						name: "rule-3",
+						PolicyRule: rbac.PolicyRule{
+							APIGroups:       []string{"api_group_4"},
+							Resources:       []string{"resource_5"},
+							Verbs:           []string{"*"},
+							ResourceNames:   []string{"sample4"},
+							NonResourceURLs: []string{"port-forward"},
+						},
 					},
 				},
 			},
@@ -52,9 +60,13 @@ func TestFilterRules(t *testing.T) {
 		{
 			input: RuleFilter{
 				PermissionType: AllPermissionType,
-				ApiGroupFilterObj: &FilterObj{
-					Args:         []string{"api_group_1"},
-					OperatorName: InOperator,
+				Filters: []Filter{
+					&APIGroupFilter{
+						Params: FilterParams{
+							Args:         []string{"api_group_1"},
+							OperatorName: InOperator,
+						},
+					},
 				},
 			},
 			expectedOutput: []string{"rule-1", "rule-2"},
@@ -62,9 +74,13 @@ func TestFilterRules(t *testing.T) {
 		{
 			input: RuleFilter{
 				PermissionType: AllPermissionType,
-				ApiGroupFilterObj: &FilterObj{
-					Args:         []string{"api_group_10"},
-					OperatorName: InOperator,
+				Filters: []Filter{
+					&APIGroupFilter{
+						Params: FilterParams{
+							Args:         []string{"api_group_10"},
+							OperatorName: InOperator,
+						},
+					},
 				},
 			},
 			expectedOutput: []string{},
@@ -72,9 +88,13 @@ func TestFilterRules(t *testing.T) {
 		{
 			input: RuleFilter{
 				PermissionType: AllPermissionType,
-				ApiGroupFilterObj: &FilterObj{
-					Args:         []string{"api_group_1"},
-					OperatorName: NotInOperator,
+				Filters: []Filter{
+					&APIGroupFilter{
+						Params: FilterParams{
+							Args:         []string{"api_group_1"},
+							OperatorName: NotInOperator,
+						},
+					},
 				},
 			},
 			expectedOutput: []string{"rule-3"},
@@ -82,9 +102,13 @@ func TestFilterRules(t *testing.T) {
 		{
 			input: RuleFilter{
 				PermissionType: AllPermissionType,
-				ResourceNamesFilterObj: &FilterObj{
-					Args:         []string{"sample1"},
-					OperatorName: InOperator,
+				Filters: []Filter{
+					&ResourceNamesFilter{
+						Params: FilterParams{
+							Args:         []string{"sample1"},
+							OperatorName: InOperator,
+						},
+					},
 				},
 			},
 			expectedOutput: []string{"rule-1"},
@@ -92,9 +116,13 @@ func TestFilterRules(t *testing.T) {
 		{
 			input: RuleFilter{
 				PermissionType: AllPermissionType,
-				ApiGroupFilterObj: &FilterObj{
-					Args:         []string{"api_group_1"},
-					OperatorName: NotEqualOperator,
+				Filters: []Filter{
+					&APIGroupFilter{
+						Params: FilterParams{
+							Args:         []string{"api_group_1"},
+							OperatorName: NotEqualOperator,
+						},
+					},
 				},
 			},
 			expectedOutput: []string{"rule-2", "rule-3"},
@@ -102,9 +130,13 @@ func TestFilterRules(t *testing.T) {
 		{
 			input: RuleFilter{
 				PermissionType: AllPermissionType,
-				ApiGroupFilterObj: &FilterObj{
-					Args:         []string{"api_group_1", "api_group_3", "api_group_2"},
-					OperatorName: EqualsOperator,
+				Filters: []Filter{
+					&APIGroupFilter{
+						Params: FilterParams{
+							Args:         []string{"api_group_1", "api_group_3", "api_group_2"},
+							OperatorName: EqualsOperator,
+						},
+					},
 				},
 			},
 			expectedOutput: []string{"rule-2"},
@@ -112,9 +144,13 @@ func TestFilterRules(t *testing.T) {
 		{
 			input: RuleFilter{
 				PermissionType: AllPermissionType,
-				ApiGroupFilterObj: &FilterObj{
-					Args:         []string{"api_group_1", "api_group_3", "api_group_2"},
-					OperatorName: EqualsOperator,
+				Filters: []Filter{
+					&APIGroupFilter{
+						Params: FilterParams{
+							Args:         []string{"api_group_1", "api_group_3", "api_group_2"},
+							OperatorName: EqualsOperator,
+						},
+					},
 				},
 			},
 			expectedOutput: []string{"rule-2"},
@@ -122,9 +158,13 @@ func TestFilterRules(t *testing.T) {
 		{
 			input: RuleFilter{
 				PermissionType: AllPermissionType,
-				NonResourceURLsFilterObj: &FilterObj{
-					Args:         []string{},
-					OperatorName: ExistsOperator,
+				Filters: []Filter{
+					&NonResourceURLsFilter{
+						Params: FilterParams{
+							Args:         []string{},
+							OperatorName: ExistsOperator,
+						},
+					},
 				},
 			},
 			expectedOutput: []string{"rule-3"},
@@ -132,9 +172,13 @@ func TestFilterRules(t *testing.T) {
 		{
 			input: RuleFilter{
 				PermissionType: AllPermissionType,
-				NonResourceURLsFilterObj: &FilterObj{
-					Args:         []string{},
-					OperatorName: DoesNotExistOperator,
+				Filters: []Filter{
+					&NonResourceURLsFilter{
+						Params: FilterParams{
+							Args:         []string{},
+							OperatorName: DoesNotExistOperator,
+						},
+					},
 				},
 			},
 			expectedOutput: []string{"rule-1", "rule-2"},
@@ -142,9 +186,13 @@ func TestFilterRules(t *testing.T) {
 		{
 			input: RuleFilter{
 				PermissionType: NameSpacedPermissionType,
-				ApiGroupFilterObj: &FilterObj{
-					Args:         []string{"api_group_1"},
-					OperatorName: InOperator,
+				Filters: []Filter{
+					&APIGroupFilter{
+						Params: FilterParams{
+							Args:         []string{"api_group_1"},
+							OperatorName: InOperator,
+						},
+					},
 				},
 			},
 			expectedOutput: []string{},
@@ -152,13 +200,19 @@ func TestFilterRules(t *testing.T) {
 		{
 			input: RuleFilter{
 				PermissionType: AllPermissionType,
-				ApiGroupFilterObj: &FilterObj{
-					Args:         []string{"api_group_1"},
-					OperatorName: InOperator,
-				},
-				ResourcesFilterObj: &FilterObj{
-					Args:         []string{"*"},
-					OperatorName: InOperator,
+				Filters: []Filter{
+					&APIGroupFilter{
+						Params: FilterParams{
+							Args:         []string{"api_group_1"},
+							OperatorName: InOperator,
+						},
+					},
+					&ResourcesFilter{
+						Params: FilterParams{
+							Args:         []string{"*"},
+							OperatorName: InOperator,
+						},
+					},
 				},
 			},
 			expectedOutput: []string{"rule-2"},
@@ -166,25 +220,50 @@ func TestFilterRules(t *testing.T) {
 		{
 			input: RuleFilter{
 				PermissionType: AllPermissionType,
-				ApiGroupFilterObj: &FilterObj{
-					Args:         []string{"api_group_1"},
-					OperatorName: NotEqualOperator,
-				},
-				VerbsFilterObj: &FilterObj{
-					Args:         []string{"*"},
-					OperatorName: InOperator,
+				Filters: []Filter{
+					&APIGroupFilter{
+						Params: FilterParams{
+							Args:         []string{"api_group_1"},
+							OperatorName: NotEqualOperator,
+						},
+					},
+					&VerbsFilter{
+						Params: FilterParams{
+							Args:         []string{"*"},
+							OperatorName: InOperator,
+						},
+					},
 				},
 			},
 			expectedOutput: []string{"rule-2", "rule-3"},
 		},
+		{
+			input: RuleFilter{
+				PermissionType: AllPermissionType,
+				Filters: []Filter{
+					&APIGroupFilter{
+						Params: FilterParams{
+							Args:         []string{"api_group_3", "api_group_1"},
+							OperatorName: AnyOperator,
+						},
+					},
+				},
+			},
+			expectedOutput: []string{"rule-1", "rule-2"},
+		},
 	}
 
 	for _, testCase := range filterCases {
-		res := inputRbacRules.FilterRules(testCase.input)
-		resRuleNames := make([]string, 0)
-		for _, item := range res {
-			resRuleNames = append(resRuleNames, item.name)
-		}
-		require.Equal(t, testCase.expectedOutput, resRuleNames)
+		tc := testCase
+		t.Run("TestFilterRules",
+			func(t *testing.T) {
+				t.Parallel()
+				res := inputRbacRules.FilterRules(tc.input)
+				resRuleNames := make([]string, 0)
+				for _, item := range res {
+					resRuleNames = append(resRuleNames, item.name)
+				}
+				require.Equal(t, tc.expectedOutput, resRuleNames)
+			})
 	}
 }

--- a/pkg/utils/csvutils/csv_rbac_utils.go
+++ b/pkg/utils/csvutils/csv_rbac_utils.go
@@ -1,0 +1,114 @@
+package csvutils
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/mt-sre/addon-metadata-operator/pkg/types"
+	"github.com/operator-framework/operator-registry/pkg/registry"
+)
+
+const wildCardStr = "*"
+
+// Checks if secrets and configmaps without explicitly defined resource names
+// are accessed at the cluster scope.
+func CheckForConfidentialObjAccessAtClusterScope(csvPermissions *types.CsvPermissions) bool {
+	filterConds := types.RuleFilter{
+		PermissionType: types.ClusterPermissionType,
+		ApiGroupFilterObj: &types.FilterObj{
+			Args:         []string{""},
+			OperatorName: types.InOperator,
+		},
+		ResourcesFilterObj: &types.FilterObj{
+			Args:         []string{"secrets", "configmaps"},
+			OperatorName: types.AnyOperator,
+		},
+		ResourceNamesFilterObj: &types.FilterObj{
+			Args:         []string{},
+			OperatorName: types.DoesNotExistOperator,
+		},
+	}
+	matchedRules := csvPermissions.FilterRules(filterConds)
+	return len(matchedRules) > 0
+}
+
+// Checks if any rules have "*" defined in its apiGroup definition.
+func WildCardApiGroupPresent(csvPermissions *types.CsvPermissions) bool {
+	filterConds := types.RuleFilter{
+		PermissionType: types.AllPermissionType,
+		ApiGroupFilterObj: &types.FilterObj{
+			Args:         []string{wildCardStr},
+			OperatorName: types.InOperator,
+		},
+	}
+	matchedRules := csvPermissions.FilterRules(filterConds)
+	return len(matchedRules) > 0
+}
+
+// Checks if any rules have "*" defined under resources.(For non-operator owned apis.)
+func WildCardResourcePresent(csvPermissions *types.CsvPermissions, ownedApis []string) bool {
+	filterConds := types.RuleFilter{
+		PermissionType: types.AllPermissionType,
+		ApiGroupFilterObj: &types.FilterObj{
+			Args:         ownedApis,
+			OperatorName: types.NotEqualOperator,
+		},
+		ResourcesFilterObj: &types.FilterObj{
+			Args:         []string{wildCardStr},
+			OperatorName: types.InOperator,
+		},
+	}
+	matchedRules := csvPermissions.FilterRules(filterConds)
+	return len(matchedRules) > 0
+}
+
+func GetApisOwned(csv *registry.ClusterServiceVersion) ([]string, error) {
+	ownedApis, _, err := csv.GetCustomResourceDefintions()
+	if err != nil {
+		return nil, err
+	}
+	result := make([]string, 0)
+	for _, api := range ownedApis {
+		if api != nil {
+			result = append(result, trimWhiteSpace(api.Group))
+		}
+	}
+	return result, nil
+}
+
+func GetPermissions(csv *registry.ClusterServiceVersion) (*types.CsvPermissions, error) {
+	var objmap map[string]*json.RawMessage
+	if err := json.Unmarshal(csv.Spec, &objmap); err != nil {
+		return nil, err
+	}
+	installData, ok := objmap["install"]
+	if !ok {
+		return nil, fmt.Errorf("Failed to parse install spec from CSV")
+	}
+	var installMap map[string]*json.RawMessage
+	if err := json.Unmarshal(*installData, &installMap); err != nil {
+		return nil, err
+	}
+
+	installSpecBytes, ok := installMap["spec"]
+	if !ok {
+		return nil, fmt.Errorf("Failed to parse install spec from CSV")
+	}
+	csvPermissions := &types.CsvPermissions{}
+	if err := json.Unmarshal(*installSpecBytes, csvPermissions); err != nil {
+		return nil, fmt.Errorf("Failed to parse install spec from CSV")
+	}
+
+	return csvPermissions, nil
+}
+
+func trimWhiteSpace(str string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) {
+			return -1
+		}
+		return r
+	}, str)
+}

--- a/pkg/utils/csvutils/csv_rbac_utils_test.go
+++ b/pkg/utils/csvutils/csv_rbac_utils_test.go
@@ -5,76 +5,87 @@ import (
 
 	"github.com/mt-sre/addon-metadata-operator/pkg/types"
 	"github.com/stretchr/testify/require"
+	rbac "k8s.io/api/rbac/v1"
 )
 
 func TestWildCardApiGroupPresent(t *testing.T) {
-	rule1 := types.CsvPermissions{
-		ClusterPermissions: []types.Permissions{
+	rule1 := types.CSVPermissions{
+		ClusterPermissions: []types.Permission{
 			{
 				Rules: []types.Rule{
 					{
-						ApiGroups:       []string{"api_group_1"},
-						Resources:       []string{"resource_1"},
-						Verbs:           []string{"*"},
-						ResourceNames:   []string{"sample1"},
-						NonResourceURLs: []string{},
+						PolicyRule: rbac.PolicyRule{
+							APIGroups:       []string{"api_group_1"},
+							Resources:       []string{"resource_1"},
+							Verbs:           []string{"*"},
+							ResourceNames:   []string{"sample1"},
+							NonResourceURLs: []string{},
+						},
 					},
 					{
-
-						ApiGroups:       []string{"api_group_2", "api_group_3", "api_group_1"},
-						Resources:       []string{"resource_2", "resource_3", "*"},
-						Verbs:           []string{"*"},
-						ResourceNames:   []string{"sample2", "sample3"},
-						NonResourceURLs: []string{},
+						PolicyRule: rbac.PolicyRule{
+							APIGroups:       []string{"api_group_2", "api_group_3", "api_group_1"},
+							Resources:       []string{"resource_2", "resource_3", "*"},
+							Verbs:           []string{"*"},
+							ResourceNames:   []string{"sample2", "sample3"},
+							NonResourceURLs: []string{},
+						},
 					},
 				},
 			},
 		},
-		Permissions: []types.Permissions{
+		Permissions: []types.Permission{
 			{
 				Rules: []types.Rule{
 					{
-						ApiGroups:       []string{"*"},
-						Resources:       []string{"resource_5"},
-						Verbs:           []string{"*"},
-						ResourceNames:   []string{"sample4"},
-						NonResourceURLs: []string{"port-forward"},
+						PolicyRule: rbac.PolicyRule{
+							APIGroups:       []string{"*"},
+							Resources:       []string{"resource_5"},
+							Verbs:           []string{"*"},
+							ResourceNames:   []string{"sample4"},
+							NonResourceURLs: []string{"port-forward"},
+						},
 					},
 				},
 			},
 		},
 	}
-	rule2 := types.CsvPermissions{
-		ClusterPermissions: []types.Permissions{
+	rule2 := types.CSVPermissions{
+		ClusterPermissions: []types.Permission{
 			{
 				Rules: []types.Rule{
 					{
-						ApiGroups:       []string{"api_group_1"},
-						Resources:       []string{"resource_1"},
-						Verbs:           []string{"*"},
-						ResourceNames:   []string{"sample1"},
-						NonResourceURLs: []string{},
+						PolicyRule: rbac.PolicyRule{
+							APIGroups:       []string{"api_group_1"},
+							Resources:       []string{"resource_1"},
+							Verbs:           []string{"*"},
+							ResourceNames:   []string{"sample1"},
+							NonResourceURLs: []string{},
+						},
 					},
 					{
-
-						ApiGroups:       []string{"api_group_2", "api_group_3", "api_group_1"},
-						Resources:       []string{"resource_2", "resource_3", "*"},
-						Verbs:           []string{"*"},
-						ResourceNames:   []string{"sample2", "sample3"},
-						NonResourceURLs: []string{},
+						PolicyRule: rbac.PolicyRule{
+							APIGroups:       []string{"api_group_2", "api_group_3", "api_group_1"},
+							Resources:       []string{"resource_2", "resource_3", "*"},
+							Verbs:           []string{"*"},
+							ResourceNames:   []string{"sample2", "sample3"},
+							NonResourceURLs: []string{},
+						},
 					},
 				},
 			},
 		},
-		Permissions: []types.Permissions{
+		Permissions: []types.Permission{
 			{
 				Rules: []types.Rule{
 					{
-						ApiGroups:       []string{"api_group_4"},
-						Resources:       []string{"resource_5"},
-						Verbs:           []string{"*"},
-						ResourceNames:   []string{"sample4"},
-						NonResourceURLs: []string{"port-forward"},
+						PolicyRule: rbac.PolicyRule{
+							APIGroups:       []string{"api_group_4"},
+							Resources:       []string{"resource_5"},
+							Verbs:           []string{"*"},
+							ResourceNames:   []string{"sample4"},
+							NonResourceURLs: []string{"port-forward"},
+						},
 					},
 				},
 			},
@@ -82,7 +93,7 @@ func TestWildCardApiGroupPresent(t *testing.T) {
 	}
 
 	testCases := []struct {
-		input          types.CsvPermissions
+		input          types.CSVPermissions
 		expectedOutput bool
 	}{
 		{
@@ -96,54 +107,65 @@ func TestWildCardApiGroupPresent(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		res := WildCardApiGroupPresent(&testCase.input)
-		require.Equal(t, testCase.expectedOutput, res)
+		tc := testCase // pin
+		t.Run(
+			"TestWildCardApiGroupPresent",
+			func(t *testing.T) {
+				t.Parallel()
+				res := WildCardApiGroupPresent(&tc.input)
+				require.Equal(t, tc.expectedOutput, res)
+			},
+		)
 	}
 }
 
 func TestWildCardResourcePresent(t *testing.T) {
-	rule1 := types.CsvPermissions{
-		ClusterPermissions: []types.Permissions{
+	rule1 := types.CSVPermissions{
+		ClusterPermissions: []types.Permission{
 			{
 				Rules: []types.Rule{
 					{
-						ApiGroups:       []string{"api_group_1"},
-						Resources:       []string{"*"},
-						Verbs:           []string{"*"},
-						ResourceNames:   []string{"sample1"},
-						NonResourceURLs: []string{},
+						PolicyRule: rbac.PolicyRule{
+							APIGroups:       []string{"api_group_1"},
+							Resources:       []string{"*"},
+							Verbs:           []string{"*"},
+							ResourceNames:   []string{"sample1"},
+							NonResourceURLs: []string{},
+						},
 					},
 				},
 			},
 		},
 	}
-	rule2 := types.CsvPermissions{
-		ClusterPermissions: []types.Permissions{
+	rule2 := types.CSVPermissions{
+		ClusterPermissions: []types.Permission{
 			{
 				Rules: []types.Rule{
 					{
-
-						ApiGroups:       []string{"api_group_2", "api_group_3", "api_group_1"},
-						Resources:       []string{"*"},
-						Verbs:           []string{"*"},
-						ResourceNames:   []string{"sample2", "sample3"},
-						NonResourceURLs: []string{},
+						PolicyRule: rbac.PolicyRule{
+							APIGroups:       []string{"api_group_2", "api_group_3", "api_group_1"},
+							Resources:       []string{"*"},
+							Verbs:           []string{"*"},
+							ResourceNames:   []string{"sample2", "sample3"},
+							NonResourceURLs: []string{},
+						},
 					},
 				},
 			},
 		},
 	}
 
-	rule3 := types.CsvPermissions{
-		ClusterPermissions: []types.Permissions{
+	rule3 := types.CSVPermissions{
+		ClusterPermissions: []types.Permission{
 			{
 				Rules: []types.Rule{
 					{
-
-						ApiGroups:       []string{""},
-						Resources:       []string{"*"},
-						Verbs:           []string{"*"},
-						NonResourceURLs: []string{},
+						PolicyRule: rbac.PolicyRule{
+							APIGroups:       []string{""},
+							Resources:       []string{"*"},
+							Verbs:           []string{"*"},
+							NonResourceURLs: []string{},
+						},
 					},
 				},
 			},
@@ -151,7 +173,7 @@ func TestWildCardResourcePresent(t *testing.T) {
 	}
 
 	testCases := []struct {
-		inputRule      types.CsvPermissions
+		inputRule      types.CSVPermissions
 		ownedApis      []string
 		expectedOutput bool
 	}{
@@ -173,85 +195,98 @@ func TestWildCardResourcePresent(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		res := WildCardResourcePresent(&testCase.inputRule, testCase.ownedApis)
-		require.Equal(t, testCase.expectedOutput, res)
+		tc := testCase
+		t.Run(
+			"TestWildCardResourcePresent",
+			func(t *testing.T) {
+				t.Parallel()
+				res := WildCardResourcePresent(&tc.inputRule, tc.ownedApis)
+				require.Equal(t, tc.expectedOutput, res)
+			},
+		)
 	}
 }
 
 func TestCheckForConfidentialObjAccessAtClusterScope(t *testing.T) {
-	rule1 := types.CsvPermissions{
-		ClusterPermissions: []types.Permissions{
+	rule1 := types.CSVPermissions{
+		ClusterPermissions: []types.Permission{
 			{
 				Rules: []types.Rule{
 					{
-						ApiGroups:       []string{""},
-						Resources:       []string{"pods", "secrets", "configmaps"},
-						Verbs:           []string{"*"},
-						ResourceNames:   []string{"sample1"},
-						NonResourceURLs: []string{},
+						PolicyRule: rbac.PolicyRule{
+							APIGroups:       []string{""},
+							Resources:       []string{"pods", "secrets", "configmaps"},
+							Verbs:           []string{"*"},
+							ResourceNames:   []string{"sample1"},
+							NonResourceURLs: []string{},
+						},
 					},
 				},
 			},
 		},
 	}
-	rule2 := types.CsvPermissions{
-		ClusterPermissions: []types.Permissions{
+	rule2 := types.CSVPermissions{
+		ClusterPermissions: []types.Permission{
 			{
 				Rules: []types.Rule{
 					{
-
-						ApiGroups:       []string{""},
-						Resources:       []string{"secrets"},
-						Verbs:           []string{"read"},
-						NonResourceURLs: []string{},
-					},
-				},
-			},
-		},
-	}
-
-	rule3 := types.CsvPermissions{
-		ClusterPermissions: []types.Permissions{
-			{
-				Rules: []types.Rule{
-					{
-
-						ApiGroups:       []string{""},
-						Resources:       []string{"configmaps"},
-						Verbs:           []string{"update"},
-						NonResourceURLs: []string{},
+						PolicyRule: rbac.PolicyRule{
+							APIGroups:       []string{""},
+							Resources:       []string{"secrets"},
+							Verbs:           []string{"read"},
+							NonResourceURLs: []string{},
+						},
 					},
 				},
 			},
 		},
 	}
 
-	rule4 := types.CsvPermissions{
-		ClusterPermissions: []types.Permissions{
+	rule3 := types.CSVPermissions{
+		ClusterPermissions: []types.Permission{
 			{
 				Rules: []types.Rule{
 					{
-
-						ApiGroups:       []string{""},
-						Resources:       []string{"configmaps", "secrets"},
-						Verbs:           []string{"update"},
-						NonResourceURLs: []string{},
+						PolicyRule: rbac.PolicyRule{
+							APIGroups:       []string{""},
+							Resources:       []string{"configmaps"},
+							Verbs:           []string{"update"},
+							NonResourceURLs: []string{},
+						},
 					},
 				},
 			},
 		},
 	}
 
-	rule5 := types.CsvPermissions{
-		Permissions: []types.Permissions{
+	rule4 := types.CSVPermissions{
+		ClusterPermissions: []types.Permission{
 			{
 				Rules: []types.Rule{
 					{
+						PolicyRule: rbac.PolicyRule{
+							APIGroups:       []string{""},
+							Resources:       []string{"configmaps", "secrets"},
+							Verbs:           []string{"update"},
+							NonResourceURLs: []string{},
+						},
+					},
+				},
+			},
+		},
+	}
 
-						ApiGroups:       []string{""},
-						Resources:       []string{"configmaps", "secrets"},
-						Verbs:           []string{"update"},
-						NonResourceURLs: []string{},
+	rule5 := types.CSVPermissions{
+		Permissions: []types.Permission{
+			{
+				Rules: []types.Rule{
+					{
+						PolicyRule: rbac.PolicyRule{
+							APIGroups:       []string{""},
+							Resources:       []string{"configmaps", "secrets"},
+							Verbs:           []string{"update"},
+							NonResourceURLs: []string{},
+						},
 					},
 				},
 			},
@@ -259,7 +294,7 @@ func TestCheckForConfidentialObjAccessAtClusterScope(t *testing.T) {
 	}
 
 	testCases := []struct {
-		inputRule      types.CsvPermissions
+		inputRule      types.CSVPermissions
 		expectedOutput bool
 	}{
 		{
@@ -285,7 +320,14 @@ func TestCheckForConfidentialObjAccessAtClusterScope(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		res := CheckForConfidentialObjAccessAtClusterScope(&testCase.inputRule)
-		require.Equal(t, testCase.expectedOutput, res)
+		tc := testCase
+		t.Run(
+			"TestCheckForConfidentialObjAccessAtClusterScope",
+			func(t *testing.T) {
+				t.Parallel()
+				res := CheckForConfidentialObjAccessAtClusterScope(&tc.inputRule)
+				require.Equal(t, tc.expectedOutput, res)
+			},
+		)
 	}
 }

--- a/pkg/utils/csvutils/csv_rbac_utils_test.go
+++ b/pkg/utils/csvutils/csv_rbac_utils_test.go
@@ -1,0 +1,291 @@
+package csvutils
+
+import (
+	"testing"
+
+	"github.com/mt-sre/addon-metadata-operator/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWildCardApiGroupPresent(t *testing.T) {
+	rule1 := types.CsvPermissions{
+		ClusterPermissions: []types.Permissions{
+			{
+				Rules: []types.Rule{
+					{
+						ApiGroups:       []string{"api_group_1"},
+						Resources:       []string{"resource_1"},
+						Verbs:           []string{"*"},
+						ResourceNames:   []string{"sample1"},
+						NonResourceURLs: []string{},
+					},
+					{
+
+						ApiGroups:       []string{"api_group_2", "api_group_3", "api_group_1"},
+						Resources:       []string{"resource_2", "resource_3", "*"},
+						Verbs:           []string{"*"},
+						ResourceNames:   []string{"sample2", "sample3"},
+						NonResourceURLs: []string{},
+					},
+				},
+			},
+		},
+		Permissions: []types.Permissions{
+			{
+				Rules: []types.Rule{
+					{
+						ApiGroups:       []string{"*"},
+						Resources:       []string{"resource_5"},
+						Verbs:           []string{"*"},
+						ResourceNames:   []string{"sample4"},
+						NonResourceURLs: []string{"port-forward"},
+					},
+				},
+			},
+		},
+	}
+	rule2 := types.CsvPermissions{
+		ClusterPermissions: []types.Permissions{
+			{
+				Rules: []types.Rule{
+					{
+						ApiGroups:       []string{"api_group_1"},
+						Resources:       []string{"resource_1"},
+						Verbs:           []string{"*"},
+						ResourceNames:   []string{"sample1"},
+						NonResourceURLs: []string{},
+					},
+					{
+
+						ApiGroups:       []string{"api_group_2", "api_group_3", "api_group_1"},
+						Resources:       []string{"resource_2", "resource_3", "*"},
+						Verbs:           []string{"*"},
+						ResourceNames:   []string{"sample2", "sample3"},
+						NonResourceURLs: []string{},
+					},
+				},
+			},
+		},
+		Permissions: []types.Permissions{
+			{
+				Rules: []types.Rule{
+					{
+						ApiGroups:       []string{"api_group_4"},
+						Resources:       []string{"resource_5"},
+						Verbs:           []string{"*"},
+						ResourceNames:   []string{"sample4"},
+						NonResourceURLs: []string{"port-forward"},
+					},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		input          types.CsvPermissions
+		expectedOutput bool
+	}{
+		{
+			input:          rule1,
+			expectedOutput: true,
+		},
+		{
+			input:          rule2,
+			expectedOutput: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		res := WildCardApiGroupPresent(&testCase.input)
+		require.Equal(t, testCase.expectedOutput, res)
+	}
+}
+
+func TestWildCardResourcePresent(t *testing.T) {
+	rule1 := types.CsvPermissions{
+		ClusterPermissions: []types.Permissions{
+			{
+				Rules: []types.Rule{
+					{
+						ApiGroups:       []string{"api_group_1"},
+						Resources:       []string{"*"},
+						Verbs:           []string{"*"},
+						ResourceNames:   []string{"sample1"},
+						NonResourceURLs: []string{},
+					},
+				},
+			},
+		},
+	}
+	rule2 := types.CsvPermissions{
+		ClusterPermissions: []types.Permissions{
+			{
+				Rules: []types.Rule{
+					{
+
+						ApiGroups:       []string{"api_group_2", "api_group_3", "api_group_1"},
+						Resources:       []string{"*"},
+						Verbs:           []string{"*"},
+						ResourceNames:   []string{"sample2", "sample3"},
+						NonResourceURLs: []string{},
+					},
+				},
+			},
+		},
+	}
+
+	rule3 := types.CsvPermissions{
+		ClusterPermissions: []types.Permissions{
+			{
+				Rules: []types.Rule{
+					{
+
+						ApiGroups:       []string{""},
+						Resources:       []string{"*"},
+						Verbs:           []string{"*"},
+						NonResourceURLs: []string{},
+					},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		inputRule      types.CsvPermissions
+		ownedApis      []string
+		expectedOutput bool
+	}{
+		{
+			inputRule:      rule1,
+			ownedApis:      []string{"api_group_1"},
+			expectedOutput: false,
+		},
+		{
+			inputRule:      rule2,
+			ownedApis:      []string{"api_group_2", "api_group_3"},
+			expectedOutput: true,
+		},
+		{
+			inputRule:      rule3,
+			ownedApis:      []string{"api_group_3"},
+			expectedOutput: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		res := WildCardResourcePresent(&testCase.inputRule, testCase.ownedApis)
+		require.Equal(t, testCase.expectedOutput, res)
+	}
+}
+
+func TestCheckForConfidentialObjAccessAtClusterScope(t *testing.T) {
+	rule1 := types.CsvPermissions{
+		ClusterPermissions: []types.Permissions{
+			{
+				Rules: []types.Rule{
+					{
+						ApiGroups:       []string{""},
+						Resources:       []string{"pods", "secrets", "configmaps"},
+						Verbs:           []string{"*"},
+						ResourceNames:   []string{"sample1"},
+						NonResourceURLs: []string{},
+					},
+				},
+			},
+		},
+	}
+	rule2 := types.CsvPermissions{
+		ClusterPermissions: []types.Permissions{
+			{
+				Rules: []types.Rule{
+					{
+
+						ApiGroups:       []string{""},
+						Resources:       []string{"secrets"},
+						Verbs:           []string{"read"},
+						NonResourceURLs: []string{},
+					},
+				},
+			},
+		},
+	}
+
+	rule3 := types.CsvPermissions{
+		ClusterPermissions: []types.Permissions{
+			{
+				Rules: []types.Rule{
+					{
+
+						ApiGroups:       []string{""},
+						Resources:       []string{"configmaps"},
+						Verbs:           []string{"update"},
+						NonResourceURLs: []string{},
+					},
+				},
+			},
+		},
+	}
+
+	rule4 := types.CsvPermissions{
+		ClusterPermissions: []types.Permissions{
+			{
+				Rules: []types.Rule{
+					{
+
+						ApiGroups:       []string{""},
+						Resources:       []string{"configmaps", "secrets"},
+						Verbs:           []string{"update"},
+						NonResourceURLs: []string{},
+					},
+				},
+			},
+		},
+	}
+
+	rule5 := types.CsvPermissions{
+		Permissions: []types.Permissions{
+			{
+				Rules: []types.Rule{
+					{
+
+						ApiGroups:       []string{""},
+						Resources:       []string{"configmaps", "secrets"},
+						Verbs:           []string{"update"},
+						NonResourceURLs: []string{},
+					},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		inputRule      types.CsvPermissions
+		expectedOutput bool
+	}{
+		{
+			inputRule:      rule1,
+			expectedOutput: false,
+		},
+		{
+			inputRule:      rule2,
+			expectedOutput: true,
+		},
+		{
+			inputRule:      rule3,
+			expectedOutput: true,
+		},
+		{
+			inputRule:      rule4,
+			expectedOutput: true,
+		},
+		{
+			inputRule:      rule5,
+			expectedOutput: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		res := CheckForConfidentialObjAccessAtClusterScope(&testCase.inputRule)
+		require.Equal(t, testCase.expectedOutput, res)
+	}
+}

--- a/pkg/validators/am0012_csv_rbac.go
+++ b/pkg/validators/am0012_csv_rbac.go
@@ -32,10 +32,6 @@ func validateCsvRbac(mb types.MetaBundle) types.ValidatorResult {
 	if err != nil {
 		return Error(err)
 	}
-	if err != nil {
-		return Error(err)
-	}
-
 	apisOwnedByOperator, err := csvutils.GetApisOwned(csv)
 	if err != nil {
 		return Error(err)
@@ -59,6 +55,7 @@ func validateCsvRbac(mb types.MetaBundle) types.ValidatorResult {
 	if err != nil {
 		return Error(err)
 	}
+
 	if len(validationErrors) == 0 {
 		return Success()
 	}
@@ -66,7 +63,7 @@ func validateCsvRbac(mb types.MetaBundle) types.ValidatorResult {
 	return Fail(failureMsg)
 }
 
-func validateApiGroups(permissions *types.CsvPermissions, existingValidationErrs []string) ([]string, error) {
+func validateApiGroups(permissions *types.CSVPermissions, existingValidationErrs []string) ([]string, error) {
 	if csvutils.WildCardApiGroupPresent(permissions) {
 		errorMsg := "Wild card string used under api group/s"
 		return append(existingValidationErrs, errorMsg), nil
@@ -74,7 +71,7 @@ func validateApiGroups(permissions *types.CsvPermissions, existingValidationErrs
 	return existingValidationErrs, nil
 }
 
-func validateWildcardInResources(csvPermissions *types.CsvPermissions,
+func validateWildcardInResources(csvPermissions *types.CSVPermissions,
 	apisOwnedByOperator []string,
 	existingValidationErrs []string) ([]string, error) {
 	if csvutils.WildCardResourcePresent(csvPermissions, apisOwnedByOperator) {
@@ -84,7 +81,7 @@ func validateWildcardInResources(csvPermissions *types.CsvPermissions,
 	return existingValidationErrs, nil
 }
 
-func validateConfidentialObjAccessAtClusterScope(csvPermissions *types.CsvPermissions,
+func validateConfidentialObjAccessAtClusterScope(csvPermissions *types.CSVPermissions,
 	existingValidationErrs []string) ([]string, error) {
 	if csvutils.CheckForConfidentialObjAccessAtClusterScope(csvPermissions) {
 		errorMsg := "config maps/Secrets access rules present at the cluster scope"

--- a/pkg/validators/am0012_csv_rbac.go
+++ b/pkg/validators/am0012_csv_rbac.go
@@ -1,0 +1,133 @@
+package validators
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mt-sre/addon-metadata-operator/pkg/types"
+	"github.com/mt-sre/addon-metadata-operator/pkg/utils/csvutils"
+	"github.com/operator-framework/operator-registry/pkg/registry"
+	"golang.org/x/mod/semver"
+)
+
+// func init() {
+// 	Registry.Add(AM0012)
+// }
+
+var AM0012 = types.Validator{
+	Code:        "AM0012",
+	Name:        "csv_permissions",
+	Description: "validates the permissions specified in the csv",
+	Runner:      validateCsvRbac,
+}
+
+func validateCsvRbac(mb types.MetaBundle) types.ValidatorResult {
+	// Only run validations on the latest bundle
+	latestBundle, err := getLatestBundle(mb.Bundles)
+	if err != nil {
+		return Error(err)
+	}
+
+	csv, err := latestBundle.ClusterServiceVersion()
+	if err != nil {
+		return Error(err)
+	}
+	if err != nil {
+		return Error(err)
+	}
+
+	apisOwnedByOperator, err := csvutils.GetApisOwned(csv)
+	if err != nil {
+		return Error(err)
+	}
+
+	permissions, err := csvutils.GetPermissions(csv)
+	if err != nil {
+		return Error(err)
+	}
+
+	validationErrors := []string{}
+	validationErrors, err = validateApiGroups(permissions, validationErrors)
+	if err != nil {
+		return Error(err)
+	}
+	validationErrors, err = validateWildcardInResources(permissions, apisOwnedByOperator, validationErrors)
+	if err != nil {
+		return Error(err)
+	}
+	validationErrors, err = validateConfidentialObjAccessAtClusterScope(permissions, validationErrors)
+	if err != nil {
+		return Error(err)
+	}
+	if len(validationErrors) == 0 {
+		return Success()
+	}
+	failureMsg := "CSV rbac validation errors: \n" + strings.Join(validationErrors, "\n")
+	return Fail(failureMsg)
+}
+
+func validateApiGroups(permissions *types.CsvPermissions, existingValidationErrs []string) ([]string, error) {
+	if csvutils.WildCardApiGroupPresent(permissions) {
+		errorMsg := "Wild card string used under api group/s"
+		return append(existingValidationErrs, errorMsg), nil
+	}
+	return existingValidationErrs, nil
+}
+
+func validateWildcardInResources(csvPermissions *types.CsvPermissions,
+	apisOwnedByOperator []string,
+	existingValidationErrs []string) ([]string, error) {
+	if csvutils.WildCardResourcePresent(csvPermissions, apisOwnedByOperator) {
+		errorMsg := "Wild card string used under resource/s not owned by the operator"
+		return append(existingValidationErrs, errorMsg), nil
+	}
+	return existingValidationErrs, nil
+}
+
+func validateConfidentialObjAccessAtClusterScope(csvPermissions *types.CsvPermissions,
+	existingValidationErrs []string) ([]string, error) {
+	if csvutils.CheckForConfidentialObjAccessAtClusterScope(csvPermissions) {
+		errorMsg := "config maps/Secrets access rules present at the cluster scope"
+		return append(existingValidationErrs, errorMsg), nil
+	}
+	return existingValidationErrs, nil
+}
+
+func getLatestBundle(bundles []registry.Bundle) (*registry.Bundle, error) {
+	if len(bundles) == 1 {
+		return &bundles[0], nil
+	}
+
+	latest := bundles[0]
+	for _, bundle := range bundles[1:] {
+		currVersion, err := getVersion(&bundle)
+		if err != nil {
+			return nil, err
+		}
+		currLatestVersion, err := getVersion(&latest)
+		if err != nil {
+			return nil, err
+		}
+
+		res := semver.Compare(currVersion, currLatestVersion)
+		// If currVersion is greater than currLatestVersion
+		if res == 1 {
+			latest = bundle
+		}
+	}
+	return &latest, nil
+}
+
+func getVersion(bundle *registry.Bundle) (string, error) {
+	csv, err := bundle.ClusterServiceVersion()
+	if err != nil {
+		return "", err
+	}
+	version, err := csv.GetVersion()
+	if err != nil {
+		return "", err
+	}
+	// Prefix a `v` infront of the version
+	// so that semver package can parse it.
+	return fmt.Sprintf("v%s", version), nil
+}

--- a/pkg/validators/am0012_test.go
+++ b/pkg/validators/am0012_test.go
@@ -1,0 +1,47 @@
+package validators_test
+
+import (
+	"github.com/mt-sre/addon-metadata-operator/internal/testutils"
+	"github.com/mt-sre/addon-metadata-operator/pkg/types"
+	"github.com/mt-sre/addon-metadata-operator/pkg/utils"
+	"github.com/mt-sre/addon-metadata-operator/pkg/validators"
+)
+
+func init() {
+	TestRegistry.Add(TestAM0012{})
+}
+
+type TestAM0012 struct{}
+
+func (val TestAM0012) Name() string {
+	return validators.AM0012.Name
+}
+
+func (val TestAM0012) Run(mb types.MetaBundle) types.ValidatorResult {
+	return validators.AM0012.Runner(mb)
+}
+
+func (val TestAM0012) SucceedingCandidates() ([]types.MetaBundle, error) {
+	res, err := testutils.DefaultSucceedingCandidates()
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func (val TestAM0012) FailingCandidates() ([]types.MetaBundle, error) {
+	invalidBundles, err := utils.ExtractAndParseAddons(
+		"quay.io/osd-addons/rhods-index@sha256:487e106059aea611af377985e6f30d7879bc36c4a16fe0f70531b7c1befd4675",
+		"rhods-operator",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	res := []types.MetaBundle{
+		{
+			Bundles: invalidBundles,
+		},
+	}
+	return res, nil
+}


### PR DESCRIPTION
# AM0012

## Description
This validator validates the rbac rules specified in the CSV file.

A short description of my validator and what it is meant to accomplish.
The validator currently runs the validations listed here: https://issues.redhat.com/browse/MTSRE-368.
I haven't enabled this validator yet, as this validation currently fails for many addons we handle currently.


## Checklist

- [ ] Wiki page exists: https://github.com/mt-sre/addon-metadata-operator/wiki/AMxxx
- [x] Followed the SOP: https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/MT-SRE/sops/AMO-validators.md
- [ ] Tested against production addons in `managed-tenants/addons/`
