### PR TITLE
goreleaser: release binary for darwin

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,7 @@ builds:
       - CGO_CFLAGS=-DSQLITE_ENABLE_JSON1
     goos:
       - linux
+      - darwin
     goarch:
       - amd64
     main: ./cmd/mtcli
@@ -28,6 +29,7 @@ builds:
 archives:
   - replacements:
       linux: Linux
+      darwin: Darwin
       386: i386
       amd64: x86_64
 checksum:


### PR DESCRIPTION
Signed-off-by: Mayank Shah <m.shah@redhat.com>

# AMxxxx

## Description

Update goreleaser to release binary for darwin

## Checklist

- [ ] Wiki page exists: https://github.com/mt-sre/addon-metadata-operator/wiki/AMxxx
- [ ] Followed the SOP: https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/MT-SRE/sops/AMO-validators.md
- [ ] Tested against production addons in `managed-tenants/addons/`
