### PR TITLE
allow displayName's regex to be able to comply with OperatorHub's style of defining [DEPRECATED] addons

### DIFF
--- a/api/v1alpha1/addonmetadata_types.go
+++ b/api/v1alpha1/addonmetadata_types.go
@@ -32,7 +32,7 @@ type AddonMetadataSpec struct {
 	ID string `json:"id" validate:"required"`
 
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Pattern=`^[0-9A-Z][A-Za-z0-9-_ ()]+$`
+	// +kubebuilder:validation:Pattern=`^[0-9A-Z\[\]][A-Za-z0-9-_ ()\[\]]+$`
 	// Friendly name for the addon, displayed in the UI
 	Name string `json:"name" validate:"required"`
 

--- a/config/crd/bases/addons.managed.openshift.io_addonmetadata.yaml
+++ b/config/crd/bases/addons.managed.openshift.io_addonmetadata.yaml
@@ -154,6 +154,7 @@ spec:
                 pattern: ^([A-Za-z -]+ <[0-9A-Za-z_.-]+@redhat\.com>,?)+$
                 type: string
               bundleParameters:
+                description: 'Deprecated: Replaced by SubscriptionConfig.'
                 properties:
                   addonParamsSecretName:
                     pattern: ^addon-[0-9A-Za-z-]+-parameters$
@@ -302,11 +303,10 @@ spec:
                 pattern: ^quay\.io/osd-addons/[a-z-]+
                 type: string
               installMode:
-                description: 'OLM InstallMode for the addon operator. One of: AllNamespaces,
-                  SingleNamespace or OwnNamespace.'
+                description: 'OLM InstallMode for the addon operator. One of: AllNamespaces
+                  or OwnNamespace.'
                 enum:
                 - AllNamespaces
-                - SingleNamespace
                 - OwnNamespace
                 type: string
               label:
@@ -343,7 +343,7 @@ spec:
                 type: object
               name:
                 description: Friendly name for the addon, displayed in the UI
-                pattern: ^[0-9A-Z][A-Za-z0-9-_ ()]+$
+                pattern: ^[0-9A-Z\[\]][A-Za-z0-9-_ ()\[\]]+$
                 type: string
               namespaceAnnotations:
                 additionalProperties:


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <ykukreja@redhat.com>

Context: https://coreos.slack.com/archives/C01L46M0FQC/p1645434725467259?thread_ts=1645431585.151349&cid=C01L46M0FQC