### PR TITLE
get rid of displayname regex (sync with managedtenants-cli)

### DIFF
--- a/api/v1alpha1/addonmetadata_types.go
+++ b/api/v1alpha1/addonmetadata_types.go
@@ -32,7 +32,6 @@ type AddonMetadataSpec struct {
 	ID string `json:"id" validate:"required"`
 
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Pattern=`^[0-9A-Z\[\]][A-Za-z0-9-_ ()\[\]]+$`
 	// Friendly name for the addon, displayed in the UI
 	Name string `json:"name" validate:"required"`
 

--- a/config/crd/bases/addons.managed.openshift.io_addonmetadata.yaml
+++ b/config/crd/bases/addons.managed.openshift.io_addonmetadata.yaml
@@ -343,7 +343,6 @@ spec:
                 type: object
               name:
                 description: Friendly name for the addon, displayed in the UI
-                pattern: ^[0-9A-Z\[\]][A-Za-z0-9-_ ()\[\]]+$
                 type: string
               namespaceAnnotations:
                 additionalProperties:


### PR DESCRIPTION
This PR syncs the recent change incorporated in managedtenants-cli which removes regex validation from the `displayName ` field in addon metadata