### PR TITLE
full docker path for goreleaser-cross image

### DIFF
--- a/build_tag.sh
+++ b/build_tag.sh
@@ -17,8 +17,8 @@ docker_run_args=(
     -v /var/run/docker.sock:/var/run/docker.sock
     -v $(pwd):/go/src/github.com/mt-sre/addon-metadata-operator
     -w /go/src/github.com/mt-sre/addon-metadata-operator
-    # goreleaser-cross version
-    goreleaser/goreleaser-cross:v1.17.6
+    # goreleaser-cross version from https://github.com/goreleaser/goreleaser-cross/pkgs/container/goreleaser-cross
+    ghcr.io/goreleaser/goreleaser-cross:v1.17.6-v1.3.1
     release --rm-dist
 )
 docker run "${docker_run_args[@]}"


### PR DESCRIPTION
the goreleaser-cross image is coming from ghcr.io and not dockerhub https://github.com/goreleaser/goreleaser-cross/pkgs/container/goreleaser-cross it should work. In the meantime, i will create a mirror for this image

## Description

A short description of my validator and what it is meant to accomplish.

## Checklist

- [ ] Wiki page exists: https://github.com/mt-sre/addon-metadata-operator/wiki/AMxxx
- [ ] Followed the SOP: https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/MT-SRE/sops/AMO-validators.md
- [ ] Tested against production addons in `managed-tenants/addons/`
