### PR TITLE
release binary name for Mac: Darwin and not macOS

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,7 +49,7 @@ archives:
       - darwin-amd64
   - replacements:
       linux: Linux
-      darwin: macOS
+      darwin: Darwin
       386: i386
       amd64: x86_64
 checksum:


### PR DESCRIPTION
small change from macOS to use Darwin as a system

## Description

A short description of my validator and what it is meant to accomplish.

## Checklist

- [ ] Wiki page exists: https://github.com/mt-sre/addon-metadata-operator/wiki/AMxxx
- [ ] Followed the SOP: https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/MT-SRE/sops/AMO-validators.md
- [ ] Tested against production addons in `managed-tenants/addons/`
