### PR TITLE
enable am0012 validator

### DIFF
--- a/pkg/validators/am0012_csv_rbac.go
+++ b/pkg/validators/am0012_csv_rbac.go
@@ -10,9 +10,9 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-// func init() {
-// 	Registry.Add(AM0012)
-// }
+func init() {
+	Registry.Add(AM0012)
+}
 
 var AM0012 = types.Validator{
 	Code:        "AM0012",


### PR DESCRIPTION
Signed-off-by: ashish <asnaraya@redhat.com>


## Description
Enable AM0012 validator


## Checklist

- [x] Wiki page exists: https://github.com/mt-sre/addon-metadata-operator/wiki/AM0012
- [x] Followed the SOP: https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/MT-SRE/sops/AMO-validators.md
- [x] Tested against production addons in `managed-tenants/addons/`
