### PR TITLE
[MTSRE-472] Extending operatorName valid length

### DIFF
--- a/api/v1alpha1/addonmetadata_types.go
+++ b/api/v1alpha1/addonmetadata_types.go
@@ -99,7 +99,7 @@ type AddonMetadataSpec struct {
 	OcmQuotaCost int `json:"ocmQuotaCost" validate:"required"`
 
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Pattern=`^[A-Za-z0-9][A-Za-z0-9-]{0,30}[A-Za-z0-9]$`
+	// +kubebuilder:validation:Pattern=`^[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9]$`
 	// Name of the addon operator.
 	OperatorName string `json:"operatorName" validate:"required"`
 

--- a/config/crd/bases/addons.managed.openshift.io_addonmetadata.yaml
+++ b/config/crd/bases/addons.managed.openshift.io_addonmetadata.yaml
@@ -372,7 +372,7 @@ spec:
                 type: string
               operatorName:
                 description: Name of the addon operator.
-                pattern: ^[A-Za-z0-9][A-Za-z0-9-]{0,30}[A-Za-z0-9]$
+                pattern: ^[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9]$
                 type: string
               pagerduty:
                 properties:


### PR DESCRIPTION
### Summary

Increases the validation length for `operatorName` beyond 32 characters.