### PR TITLE
Fixing `AM0012` false failures for newly on-boarded addons

### DIFF
--- a/pkg/validators/am0012_csv_rbac.go
+++ b/pkg/validators/am0012_csv_rbac.go
@@ -22,6 +22,11 @@ var AM0012 = types.Validator{
 }
 
 func validateCsvRbac(mb types.MetaBundle) types.ValidatorResult {
+	// Guard against addons which do not have bundles yet
+	if len(mb.Bundles) == 0 {
+		return Success()
+	}
+
 	// Only run validations on the latest bundle
 	latestBundle, err := getLatestBundle(mb.Bundles)
 	if err != nil {

--- a/pkg/validators/am0012_test.go
+++ b/pkg/validators/am0012_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/mt-sre/addon-metadata-operator/pkg/types"
 	"github.com/mt-sre/addon-metadata-operator/pkg/utils"
 	"github.com/mt-sre/addon-metadata-operator/pkg/validators"
+	"github.com/operator-framework/operator-registry/pkg/registry"
 )
 
 func init() {
@@ -26,6 +27,11 @@ func (val TestAM0012) SucceedingCandidates() ([]types.MetaBundle, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	res = append(res, types.MetaBundle{
+		Bundles: []registry.Bundle{},
+	})
+
 	return res, nil
 }
 


### PR DESCRIPTION
### Summary

Prevents false failures when a new addon is on-boarding and does not have any bundles yet.