### PR TITLE
[MTSRE-500] Using PackageName to extract Addons

### DIFF
--- a/api/v1alpha1/addonmetadata_types.go
+++ b/api/v1alpha1/addonmetadata_types.go
@@ -102,6 +102,11 @@ type AddonMetadataSpec struct {
 	// Name of the addon operator.
 	OperatorName string `json:"operatorName" validate:"required"`
 
+	// +optional
+	// +kubebuilder:validation:Pattern=`^[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9]$`
+	// Name of the addon OLM package. Defaults to operatorName when not specified.
+	PackageName string `json:"packageName" validate:"required"`
+
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum={alpha,beta,stable,edge,rc}
 	// OLM channel from which to install the addon-operator. One of: alpha, beta, stable, edge or rc.

--- a/config/crd/bases/addonsflow.redhat.openshift.io_addonmetadata.yaml
+++ b/config/crd/bases/addonsflow.redhat.openshift.io_addonmetadata.yaml
@@ -373,6 +373,10 @@ spec:
                 description: Name of the addon operator.
                 pattern: ^[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9]$
                 type: string
+              packageName:
+                description: Name of the addon OLM package. Defaults to operatorName when not specified.
+                pattern: ^[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9]$
+                type: string
               pagerduty:
                 properties:
                   acknowledgeTimeout:

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -69,7 +69,7 @@ func validateMain(cmd *cobra.Command, args []string) {
 		fail(1, "unable to load addon metadata from file '%v': %v", addonDir, err)
 	}
 
-	bundles, err := utils.ExtractAndParseAddons(*meta.IndexImage, meta.OperatorName)
+	bundles, err := utils.ExtractAndParseAddons(*meta.IndexImage, meta.PackageName)
 	if err != nil {
 		fail(1, "unable to extract and parse bundles from the given index image: %v", err)
 	}

--- a/pkg/utils/bundle_utils_test.go
+++ b/pkg/utils/bundle_utils_test.go
@@ -13,26 +13,26 @@ func TestExtractAndParseAddons(t *testing.T) {
 	defer testutils.RemoveDir(utils.DefaultDownloadPath)
 	testCases := []struct {
 		indexImage             string
-		operatorName           string
+		packageName            string
 		expectedErrorSubstring *string
 	}{
 		{
 			indexImage:             "quay.io/osd-addons/reference-addon-index@sha256:b9e87a598e7fd6afb4bfedb31e4098435c2105cc8ebe33231c341e515ba9054d",
-			operatorName:           "reference-addon",
+			packageName:            "reference-addon",
 			expectedErrorSubstring: nil,
 		},
 		{
 			indexImage:             "quay.io/osd-addons/reference-addon-index@sha256:b9e87a598e7fd6afb4bfedb31e4098435c2105cc8ebe33231c341e515ba9054d",
-			operatorName:           "lorem-ipsum",
+			packageName:            "lorem-ipsum",
 			expectedErrorSubstring: testutils.GetStringLiteralRef("can't find any bundles for the operator 'lorem-ipsum'"),
 		},
 	}
 
 	for _, tc := range testCases {
 		tc := tc // pin
-		t.Run(tc.operatorName, func(t *testing.T) {
+		t.Run(tc.packageName, func(t *testing.T) {
 			t.Parallel()
-			bundles, err := utils.ExtractAndParseAddons(tc.indexImage, tc.operatorName)
+			bundles, err := utils.ExtractAndParseAddons(tc.indexImage, tc.packageName)
 			if tc.expectedErrorSubstring == nil {
 				require.Greater(t, len(bundles), 0)
 				require.NoError(t, err)


### PR DESCRIPTION
## Description

A new PackageName property was introduced here:
https://github.com/mt-sre/managed-tenants-cli/pull/134

The PackageName is what we are actually looking for. Most of the time,
it's the same as the OepratorName, but not always.

Depends on https://github.com/mt-sre/managed-tenants-cli/pull/134