### PR TITLE
[MTSRE-502] AM0013 validator for addon requirements

### DIFF
--- a/pkg/validator/am0013/addon_requirements.go
+++ b/pkg/validator/am0013/addon_requirements.go
@@ -1,0 +1,60 @@
+package am0013
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mt-sre/addon-metadata-operator/pkg/types"
+	"github.com/mt-sre/addon-metadata-operator/pkg/validator"
+)
+
+func init() {
+	validator.Register(NewAddonRequirements)
+}
+
+const (
+	code = 13
+	name = "addon_requirements"
+	desc = "Ensure `addOnRequirements` section in the addon metadata is rightfully defined"
+)
+
+func NewAddonRequirements(deps validator.Dependencies) (validator.Validator, error) {
+	base, err := validator.NewBase(
+		code,
+		validator.BaseName(name),
+		validator.BaseDesc(desc),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AddonRequirements{
+		Base: base,
+	}, nil
+}
+
+type AddonRequirements struct {
+	*validator.Base
+}
+
+func (a *AddonRequirements) Run(ctx context.Context, mb types.MetaBundle) validator.Result {
+	requirements := mb.AddonMeta.AddOnRequirements
+
+	if requirements == nil {
+		return a.Success()
+	}
+
+	var msgs []string
+
+	for _, r := range *requirements {
+		if len(r.Data) == 0 {
+			msgs = append(msgs, fmt.Sprintf("requirement %q has no data", r.ID))
+		}
+	}
+
+	if len(msgs) == 0 {
+		return a.Success()
+	}
+
+	return a.Fail(msgs...)
+}

--- a/pkg/validator/am0013/addon_requirements_test.go
+++ b/pkg/validator/am0013/addon_requirements_test.go
@@ -1,0 +1,108 @@
+package am0013
+
+import (
+	"testing"
+
+	"github.com/mt-sre/addon-metadata-operator/api/v1alpha1"
+	ocmv1 "github.com/mt-sre/addon-metadata-operator/pkg/ocm/v1"
+	"github.com/mt-sre/addon-metadata-operator/pkg/types"
+	utils "github.com/mt-sre/addon-metadata-operator/pkg/validator/testutils"
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func TestAddonParametersValid(t *testing.T) {
+	t.Parallel()
+
+	bundles, err := utils.DefaultValidBundleMap()
+	require.NoError(t, err)
+
+	for name, bundle := range map[string]types.MetaBundle{
+		"no addon requirements": {
+			AddonMeta: &v1alpha1.AddonMetadataSpec{},
+		},
+		"single addon requirement with data": {
+			AddonMeta: &v1alpha1.AddonMetadataSpec{
+				AddOnRequirements: &[]ocmv1.AddOnRequirement{
+					{
+						ID: "has data",
+						Data: ocmv1.AddOnRequirementData{
+							"key": apiextensionsv1.JSON{},
+						},
+					},
+				},
+			},
+		},
+		"multiple addon requirement with data": {
+			AddonMeta: &v1alpha1.AddonMetadataSpec{
+				AddOnRequirements: &[]ocmv1.AddOnRequirement{
+					{
+						ID: "has data",
+						Data: ocmv1.AddOnRequirementData{
+							"key": apiextensionsv1.JSON{},
+						},
+					},
+					{
+						ID: "has more data",
+						Data: ocmv1.AddOnRequirementData{
+							"key": apiextensionsv1.JSON{},
+						},
+					},
+				},
+			},
+		},
+	} {
+		bundles[name] = bundle
+	}
+
+	tester := utils.NewValidatorTester(t, NewAddonRequirements)
+	tester.TestValidBundles(bundles)
+}
+
+func TestAddonParametersInvalid(t *testing.T) {
+	t.Parallel()
+
+	tester := utils.NewValidatorTester(t, NewAddonRequirements)
+	tester.TestInvalidBundles(map[string]types.MetaBundle{
+		"single addon requirement without data": {
+			AddonMeta: &v1alpha1.AddonMetadataSpec{
+				AddOnRequirements: &[]ocmv1.AddOnRequirement{
+					{
+						ID:   "has no data",
+						Data: ocmv1.AddOnRequirementData{},
+					},
+				},
+			},
+		},
+		"multiple addon requirement without data": {
+			AddonMeta: &v1alpha1.AddonMetadataSpec{
+				AddOnRequirements: &[]ocmv1.AddOnRequirement{
+					{
+						ID:   "has no data",
+						Data: ocmv1.AddOnRequirementData{},
+					},
+					{
+						ID:   "also has no data",
+						Data: ocmv1.AddOnRequirementData{},
+					},
+				},
+			},
+		},
+		"multiple addon requirement with and without data": {
+			AddonMeta: &v1alpha1.AddonMetadataSpec{
+				AddOnRequirements: &[]ocmv1.AddOnRequirement{
+					{
+						ID:   "has no data",
+						Data: ocmv1.AddOnRequirementData{},
+					},
+					{
+						ID: "has data",
+						Data: ocmv1.AddOnRequirementData{
+							"key": apiextensionsv1.JSON{},
+						},
+					},
+				},
+			},
+		},
+	})
+}

--- a/pkg/validator/register/register.go
+++ b/pkg/validator/register/register.go
@@ -12,4 +12,5 @@ import (
 	_ "github.com/mt-sre/addon-metadata-operator/pkg/validator/am0010"
 	_ "github.com/mt-sre/addon-metadata-operator/pkg/validator/am0011"
 	_ "github.com/mt-sre/addon-metadata-operator/pkg/validator/am0012"
+	_ "github.com/mt-sre/addon-metadata-operator/pkg/validator/am0013"
 )


### PR DESCRIPTION
# AM0013

## Description

Validates `addonRequirements` in particular that they contain non-empty data.

## Checklist

- [x] Wiki page exists: https://github.com/mt-sre/addon-metadata-operator/wiki/AM0013
- [x] Followed the SOP: https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/MT-SRE/sops/AMO-validators.md
- [x] Tested against production addons in `managed-tenants/addons/`
