### PR TITLE
[MTSRE-407] feat: new command for converting metadata to k8s resources

### DIFF
--- a/api/v1alpha1/addonmetadata_types.go
+++ b/api/v1alpha1/addonmetadata_types.go
@@ -19,6 +19,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const AddonMetadataKind = "AddonMetadata"
+
 // AddonMetadataSpec defines the desired state of AddonMetadata
 // View markers: $ controller-gen -www crd
 // TODO add missing fields from schema, only required fields from jsonschema are present

--- a/api/v1alpha1/addonmetadata_utils.go
+++ b/api/v1alpha1/addonmetadata_utils.go
@@ -4,17 +4,22 @@ import (
 	"encoding/json"
 
 	ocmv1 "github.com/mt-sre/addon-metadata-operator/pkg/ocm/v1"
-	"k8s.io/apimachinery/pkg/util/yaml"
+	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 // FromYAML - instantiates an AddonMetadataSpec struct from yaml data
 func (a *AddonMetadataSpec) FromYAML(data []byte) error {
-	return yaml.Unmarshal(data, a)
+	return yamlutil.Unmarshal(data, a)
 }
 
 // ToJSON - marshal AddonMetadata to JSON
 func (a *AddonMetadata) ToJSON() ([]byte, error) {
 	return json.Marshal(a)
+}
+
+func (a *AddonMetadata) ToYAML() ([]byte, error) {
+	return yaml.Marshal(a)
 }
 
 // CombineWithImageSet - Returns a new AddonMetadataSpec combined with the

--- a/go.mod
+++ b/go.mod
@@ -28,4 +28,5 @@ require (
 	k8s.io/client-go v0.22.2
 	rsc.io/letsencrypt v0.0.3 // indirect
 	sigs.k8s.io/controller-runtime v0.10.1
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/internal/cmd/convert.go
+++ b/internal/cmd/convert.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/mt-sre/addon-metadata-operator/api/v1alpha1"
+	"github.com/mt-sre/addon-metadata-operator/pkg/utils"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type convertOptions struct {
+	Env     string
+	Version string
+}
+
+func init() {
+	var opts convertOptions
+
+	cmd := &cobra.Command{
+		Use:   "convert ADDON_DIR",
+		Short: "Convert metadata to Addon Custom Resource",
+		RunE:  convert(&opts),
+	}
+
+	cmd.Flags().StringVar(&opts.Env, "environment", "stage", "specifies which environment's metadata to convert")
+	cmd.Flags().StringVar(&opts.Version, "version", "", "specifies which imageset version to load")
+
+	mtcli.AddCommand(cmd)
+}
+
+func convert(opts *convertOptions) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		addonDir, err := parseAddonDir(args[0])
+		if err != nil {
+			return fmt.Errorf("reading addon directory: %w", err)
+		}
+
+		meta, err := utils.NewMetaLoader(addonDir, opts.Env, opts.Version).Load()
+		if err != nil {
+			return fmt.Errorf("loading addon metadta: %w", err)
+		}
+
+		cr := v1alpha1.AddonMetadata{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       v1alpha1.AddonMetadataKind,
+				APIVersion: v1alpha1.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: meta.ID,
+			},
+			Spec: *meta,
+		}
+
+		data, err := cr.ToYAML()
+		if err != nil {
+			return fmt.Errorf("converting addon to yaml: %w", err)
+		}
+
+		if _, err := fmt.Fprint(os.Stdout, string(data)); err != nil {
+			return fmt.Errorf("printing output: %w", err)
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
### Summary

Adds `convert` command to `mtcli` for converting addon metadata to `AddonMetadta` Custom Resources.