### PR TITLE
Ensure concise output from `mtcli validate`

### DIFF
--- a/cmd/mtcli/validate/cmd.go
+++ b/cmd/mtcli/validate/cmd.go
@@ -41,12 +41,14 @@ func Cmd() *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:     "validate",
-		Short:   "Validate addon metadata, bundles and imagesets.",
-		Long:    long,
-		Example: examples(),
-		Args:    cobra.ExactArgs(1),
-		RunE:    run(opts),
+		Use:           "validate",
+		Short:         "Validate addon metadata, bundles and imagesets.",
+		Long:          long,
+		Example:       examples(),
+		Args:          cobra.ExactArgs(1),
+		RunE:          run(opts),
+		SilenceErrors: true,
+		SilenceUsage:  true,
 	}
 
 	flags := cmd.PersistentFlags()

--- a/pkg/validator/ocm_client.go
+++ b/pkg/validator/ocm_client.go
@@ -135,7 +135,7 @@ func (c *DefaultOCMClient) initConnection() error {
 }
 
 func (c *DefaultOCMClient) QuotaRuleExists(ctx context.Context, quotaName string) (bool, error) {
-	if c.conn == nil {
+	if c == nil || c.conn == nil {
 		return false, errors.New("no active OCM connection")
 	}
 
@@ -163,7 +163,7 @@ func (c *DefaultOCMClient) QuotaRuleExists(ctx context.Context, quotaName string
 }
 
 func (c *DefaultOCMClient) CloseConnection() error {
-	if c.conn == nil {
+	if c == nil || c.conn == nil {
 		return nil
 	}
 


### PR DESCRIPTION
### Summary

A couple of minor fixes to avoid overloaded error output when `mtcli validate` encounters a failure or error.