### PR TITLE
[MTSRE-390] AMO: validate annotations on AM0001 and AM0003

### DIFF
--- a/pkg/validator/am0001/default_channel_test.go
+++ b/pkg/validator/am0001/default_channel_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mt-sre/addon-metadata-operator/api/v1alpha1"
 	"github.com/mt-sre/addon-metadata-operator/pkg/types"
 	"github.com/mt-sre/addon-metadata-operator/pkg/validator/testutils"
+	"github.com/operator-framework/operator-registry/pkg/registry"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,6 +57,63 @@ func TestDefaultChannelInvalid(t *testing.T) {
 			AddonMeta: &v1alpha1.AddonMetadataSpec{
 				ID:             "random-operator",
 				DefaultChannel: "invalid",
+			},
+		},
+		"not present in bundle channels annotation": {
+			AddonMeta: &v1alpha1.AddonMetadataSpec{
+				ID:             "random-operator",
+				DefaultChannel: "alpha",
+				Channels: &[]v1alpha1.Channel{
+					{
+						Name: "alpha",
+					},
+				},
+			},
+			Bundles: []*registry.Bundle{
+				{
+					Annotations: &registry.Annotations{
+						DefaultChannelName: "alpha",
+						Channels:           "beta,stable,rc",
+					},
+				},
+			},
+		},
+		"not present in the bundle default channel": {
+			AddonMeta: &v1alpha1.AddonMetadataSpec{
+				ID:             "random-operator",
+				DefaultChannel: "alpha",
+				Channels: &[]v1alpha1.Channel{
+					{
+						Name: "alpha",
+					},
+				},
+			},
+			Bundles: []*registry.Bundle{
+				{
+					Annotations: &registry.Annotations{
+						DefaultChannelName: "beta",
+						Channels:           "beta,stable,rc,alpha",
+					},
+				},
+			},
+		},
+		"DefaultChannel is not alpha for bundle default channel not defined": {
+			AddonMeta: &v1alpha1.AddonMetadataSpec{
+				ID:             "random-operator",
+				DefaultChannel: "stable",
+				Channels: &[]v1alpha1.Channel{
+					{
+						Name: "stable",
+					},
+				},
+			},
+			Bundles: []*registry.Bundle{
+				{
+					Annotations: &registry.Annotations{
+						DefaultChannelName: "",
+						Channels:           "stable,beta",
+					},
+				},
 			},
 		},
 	})


### PR DESCRIPTION
Signed-off-by: Ankit Kurmi <akurmi@redhat.com>

## Description

Added validation for annotations for validators AM0001 (AM0003 is already covered in PR #111).
## Checklist

- [x] Wiki page exists: https://github.com/mt-sre/addon-metadata-operator/wiki/AM0001
- [x] Followed the SOP: https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/MT-SRE/sops/AMO-validators.md
- [x] Tested against production addons in `managed-tenants/addons/`
