### PR TITLE
fix: make AM0003 tolerant of 'v' pre-fixed semver

### DIFF
--- a/pkg/validator/am0003/operator_name.go
+++ b/pkg/validator/am0003/operator_name.go
@@ -111,7 +111,7 @@ func validateBundleIdentifier(id, operatorName string) string {
 		return fmt.Sprintf("invalid operatorName for %q; expected %q", id, operatorName)
 	}
 
-	if _, err := semver.Parse(bundleVersion); err != nil {
+	if _, err := semver.ParseTolerant(bundleVersion); err != nil {
 		return fmt.Sprintf("invalid semver %q: %v", id, err)
 	}
 


### PR DESCRIPTION
### Summary

Semver can be tolerant of `v` pre-fixed versions in `.metadata.name` and `.spec.replaces` as OPM does not correlate `.spec.version` with these values.
