### PR TITLE
feat: adding new deployment linter

### DIFF
--- a/internal/kube/lint.go
+++ b/internal/kube/lint.go
@@ -1,0 +1,167 @@
+package kube
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type DeploymentLinter interface {
+	Lint(d appsv1.Deployment) DeploymentCheckResult
+}
+
+func NewDeploymentCheckResult(reasons ...string) DeploymentCheckResult {
+	if len(reasons) > 0 {
+		return DeploymentCheckResult{
+			Success: false,
+			Reasons: reasons,
+		}
+	}
+
+	return DeploymentCheckResult{
+		Success: true,
+	}
+}
+
+type DeploymentCheckResult struct {
+	Success bool
+	Reasons []string
+}
+
+func (r DeploymentCheckResult) Join(other DeploymentCheckResult) DeploymentCheckResult {
+	return DeploymentCheckResult{
+		Success: r.Success && other.Success,
+		Reasons: append(r.Reasons, other.Reasons...),
+	}
+}
+
+type DeploymentCheckResultList []DeploymentCheckResult
+
+func (l DeploymentCheckResultList) Reduce() DeploymentCheckResult {
+	res := NewDeploymentCheckResult()
+
+	for _, result := range l {
+		res = res.Join(result)
+	}
+
+	return res
+}
+
+func NewDeploymentLinterImpl(opts ...DeploymentLinterImplOption) *DeploymentLinterImpl {
+	var cfg DeploymentLinterImplConfig
+
+	cfg.Option(opts...)
+	cfg.Default()
+
+	return &DeploymentLinterImpl{
+		cfg: cfg,
+	}
+}
+
+type DeploymentLinterImpl struct {
+	cfg DeploymentLinterImplConfig
+}
+
+func (dv *DeploymentLinterImpl) Lint(d appsv1.Deployment) DeploymentCheckResult {
+	var results DeploymentCheckResultList
+
+	for _, check := range dv.cfg.checks {
+		results = append(results, check(d))
+	}
+
+	return results.Reduce()
+}
+
+type DeploymentLinterImplConfig struct {
+	checks []DeploymentCheck
+}
+
+func (c *DeploymentLinterImplConfig) Option(opts ...DeploymentLinterImplOption) {
+	for _, opt := range opts {
+		opt.ConfigureDeploymentValidator(c)
+	}
+}
+
+func (c *DeploymentLinterImplConfig) Default() {
+	if len(c.checks) == 0 {
+		c.checks = []DeploymentCheck{
+			HasLivenessProbes,
+			HasReadinessProbes,
+			HasCPUResourceRequirements,
+			HasMemoryResourceRequirements,
+		}
+	}
+}
+
+type DeploymentLinterImplOption interface {
+	ConfigureDeploymentValidator(*DeploymentLinterImplConfig)
+}
+
+type WithDeploymentChecks []DeploymentCheck
+
+func (w WithDeploymentChecks) ConfigureDeploymentLinter(c *DeploymentLinterImplConfig) {
+	c.checks = []DeploymentCheck(w)
+}
+
+type DeploymentCheck func(appsv1.Deployment) DeploymentCheckResult
+
+func HasReadinessProbes(d appsv1.Deployment) DeploymentCheckResult {
+	var reasons []string
+
+	for _, c := range d.Spec.Template.Spec.Containers {
+		if c.ReadinessProbe == nil {
+			reasons = append(reasons, reportContainerLintReason(c, "missing a readiness probe"))
+		}
+	}
+
+	return NewDeploymentCheckResult(reasons...)
+}
+
+func HasLivenessProbes(d appsv1.Deployment) DeploymentCheckResult {
+	var reasons []string
+
+	for _, c := range d.Spec.Template.Spec.Containers {
+		if c.LivenessProbe == nil {
+			reasons = append(reasons, reportContainerLintReason(c, "missing a liveness probe"))
+		}
+	}
+
+	return NewDeploymentCheckResult(reasons...)
+}
+
+func HasCPUResourceRequirements(d appsv1.Deployment) DeploymentCheckResult {
+	var reasons []string
+
+	for _, c := range d.Spec.Template.Spec.Containers {
+		if c.Resources.Requests.Cpu().IsZero() {
+			reasons = append(reasons, reportContainerLintReason(c, "missing CPU requests"))
+		}
+
+		if c.Resources.Limits.Cpu().IsZero() {
+			reasons = append(reasons, reportContainerLintReason(c, "missing CPU limits"))
+		}
+	}
+
+	return NewDeploymentCheckResult(reasons...)
+}
+
+func HasMemoryResourceRequirements(d appsv1.Deployment) DeploymentCheckResult {
+	var reasons []string
+
+	for _, c := range d.Spec.Template.Spec.Containers {
+		if c.Resources.Requests.Memory().IsZero() {
+			reasons = append(reasons, reportContainerLintReason(c, "missing memory requests"))
+		}
+
+		if c.Resources.Limits.Memory().IsZero() {
+			reasons = append(reasons, reportContainerLintReason(c, "missing memory limits"))
+		}
+	}
+
+	return NewDeploymentCheckResult(reasons...)
+}
+
+func reportContainerLintReason(c corev1.Container, reason string) string {
+	return fmt.Sprintf("container %q is %s", c.Name, reason)
+}

--- a/internal/kube/lint_test.go
+++ b/internal/kube/lint_test.go
@@ -1,0 +1,168 @@
+package kube
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestDeploymentLinterImplInterfaces(t *testing.T) {
+	t.Parallel()
+
+	require.Implements(t, new(DeploymentLinter), new(DeploymentLinterImpl))
+}
+
+func TestDeploymentLinterImpl(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		Deployment      appsv1.Deployment
+		ExpectedSuccess bool
+	}{
+		"default checks/valid deployment": {
+			Deployment: newTestDeployment(corev1.Container{
+				ReadinessProbe: &corev1.Probe{},
+				LivenessProbe:  &corev1.Probe{},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(500, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(1000, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(2048, resource.BinarySI),
+					},
+				},
+			}),
+			ExpectedSuccess: true,
+		},
+		"default checks/missing Readiness Probe": {
+			Deployment: newTestDeployment(corev1.Container{
+				LivenessProbe: &corev1.Probe{},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(500, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(1000, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(2048, resource.BinarySI),
+					},
+				},
+			}),
+			ExpectedSuccess: false,
+		},
+		"default checks/missing liveness Probe": {
+			Deployment: newTestDeployment(corev1.Container{
+				ReadinessProbe: &corev1.Probe{},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(500, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(1000, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(2048, resource.BinarySI),
+					},
+				},
+			}),
+			ExpectedSuccess: false,
+		},
+		"default checks/missing CPU requests": {
+			Deployment: newTestDeployment(corev1.Container{
+				ReadinessProbe: &corev1.Probe{},
+				LivenessProbe:  &corev1.Probe{},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(1000, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(2048, resource.BinarySI),
+					},
+				},
+			}),
+			ExpectedSuccess: false,
+		},
+		"default checks/missing CPU limits": {
+			Deployment: newTestDeployment(corev1.Container{
+				ReadinessProbe: &corev1.Probe{},
+				LivenessProbe:  &corev1.Probe{},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(500, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: *resource.NewQuantity(2048, resource.BinarySI),
+					},
+				},
+			}),
+			ExpectedSuccess: false,
+		},
+		"default checks/missing memory requests": {
+			Deployment: newTestDeployment(corev1.Container{
+				ReadinessProbe: &corev1.Probe{},
+				LivenessProbe:  &corev1.Probe{},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: *resource.NewQuantity(500, resource.DecimalSI),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(1000, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(2048, resource.BinarySI),
+					},
+				},
+			}),
+			ExpectedSuccess: false,
+		},
+		"default checks/missing memory limits": {
+			Deployment: newTestDeployment(corev1.Container{
+				ReadinessProbe: &corev1.Probe{},
+				LivenessProbe:  &corev1.Probe{},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    *resource.NewQuantity(500, resource.DecimalSI),
+						corev1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU: *resource.NewQuantity(1000, resource.DecimalSI),
+					},
+				},
+			}),
+			ExpectedSuccess: false,
+		},
+		"default checks/multiple issues": {
+			Deployment:      newTestDeployment(corev1.Container{}),
+			ExpectedSuccess: false,
+		},
+	} {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			val := NewDeploymentLinterImpl()
+
+			res := val.Lint(tc.Deployment)
+
+			assert.Equal(t, tc.ExpectedSuccess, res.Success, res)
+		})
+	}
+}
+
+func newTestDeployment(containers ...corev1.Container) appsv1.Deployment {
+	return appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: containers,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
### Summary

Adds a linter for K8s deployments. Hopefully this is a temporary implementation until `kube-linter` import conflicts can be resolved.
