### PR TITLE
fix: deprecating pullSecret from AMO API

### DIFF
--- a/api/v1alpha1/addonmetadata_types.go
+++ b/api/v1alpha1/addonmetadata_types.go
@@ -154,9 +154,6 @@ type AddonMetadataSpec struct {
 	ManualInstallPlanApproval *bool `json:"manualInstallPlanApproval"`
 
 	// +optional
-	PullSecret string `json:"pullSecret"`
-
-	// +optional
 	// Labels to be applied to all objects created in the SelectorSyncSet.
 	CommonLabels *map[string]string `json:"commonLabels"`
 


### PR DESCRIPTION
Signed-off-by: Ankit Kurmi <akurmi@redhat.com>

## Description
Deprecating `pullSecret` from AMO API.

