### PR TITLE
[MTSRE-741] AM0018 Addon pullSecretName should be a part of secrets.

### DIFF
--- a/pkg/validator/am0018/pull_secret_name.go
+++ b/pkg/validator/am0018/pull_secret_name.go
@@ -1,0 +1,63 @@
+package am0018
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mt-sre/addon-metadata-operator/pkg/types"
+	"github.com/mt-sre/addon-metadata-operator/pkg/validator"
+)
+
+func init() {
+	validator.Register(NewPullSecretname)
+}
+
+const (
+	code = 18
+	name = "pull_secret_name"
+	desc = "Ensure that pullSecretName if not nil is present in Secrets"
+)
+
+func NewPullSecretname(deps validator.Dependencies) (validator.Validator, error) {
+	base, err := validator.NewBase(
+		code,
+		validator.BaseName(name),
+		validator.BaseDesc(desc),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &PullSecretname{
+		Base: base,
+	}, nil
+}
+
+type PullSecretname struct {
+	*validator.Base
+}
+
+func (p *PullSecretname) Run(ctx context.Context, mb types.MetaBundle) validator.Result {
+	pullSecretName := mb.AddonMeta.PullSecretName
+	if pullSecretName == "" {
+		return p.Success()
+	}
+
+	config := mb.AddonMeta.Config
+	// if config is nil
+	if config == nil {
+		return p.Fail(fmt.Sprintf("pullSecretName %v is present in addon.yaml whereas addon config is nil", pullSecretName))
+	}
+
+	secrets := config.Secrets
+	// if secrets is nil
+	if secrets == nil {
+		return p.Fail(fmt.Sprintf("pullSecretName %v is present in addon.yaml whereas addon secrets are nil", pullSecretName))
+	}
+
+	for _, secret := range *secrets {
+		if pullSecretName == secret.Name {
+			return p.Success()
+		}
+	}
+	return p.Fail(fmt.Sprintf("pullSecretName %v is not present in addon secrets", pullSecretName))
+}

--- a/pkg/validator/am0018/pull_secret_name_test.go
+++ b/pkg/validator/am0018/pull_secret_name_test.go
@@ -1,0 +1,102 @@
+package am0018
+
+import (
+	"testing"
+
+	"github.com/mt-sre/addon-metadata-operator/api/v1alpha1"
+	mtsrev1 "github.com/mt-sre/addon-metadata-operator/pkg/mtsre/v1"
+	"github.com/mt-sre/addon-metadata-operator/pkg/types"
+	"github.com/mt-sre/addon-metadata-operator/pkg/validator/testutils"
+)
+
+func TestNewPullSecretnameValid(t *testing.T) {
+	t.Parallel()
+
+	tester := testutils.NewValidatorTester(t, NewPullSecretname)
+	tester.TestValidBundles(map[string]types.MetaBundle{
+		"pullSecretName is not present and config is nil": {
+			AddonMeta: &v1alpha1.AddonMetadataSpec{
+				PullSecretName: "",
+				Config:         nil,
+			},
+		},
+		"pullSecretname is not present and secrets are nil": {
+			AddonMeta: &v1alpha1.AddonMetadataSpec{
+				PullSecretName: "",
+				Config: &mtsrev1.Config{
+					Secrets: nil,
+				},
+			},
+		},
+		"pullSecretName is present and addon has one secret": {
+			AddonMeta: &v1alpha1.AddonMetadataSpec{
+				PullSecretName: "test-pull-secret",
+				Config: &mtsrev1.Config{
+					Secrets: &[]mtsrev1.Secret{
+						{
+							Name: "test-pull-secret",
+						},
+					},
+				},
+			},
+		},
+		"pullSecretName is present and addon has multiple secrets defined": {
+			AddonMeta: &v1alpha1.AddonMetadataSpec{
+				PullSecretName: "test-pull-secret-2",
+				Config: &mtsrev1.Config{
+					Secrets: &[]mtsrev1.Secret{
+						{
+							Name: "test-pull-secret-1",
+						},
+						{
+							Name: "test-pull-secret-2",
+						},
+						{
+							Name: "test-pull-secret-2",
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestNewPullSecretnameInvalid(t *testing.T) {
+	t.Parallel()
+
+	tester := testutils.NewValidatorTester(t, NewPullSecretname)
+	tester.TestInvalidBundles(map[string]types.MetaBundle{
+		"pullSecretName is not nil but addon Config is nil": {
+			AddonMeta: &v1alpha1.AddonMetadataSpec{
+				PullSecretName: "test-pull-secret",
+				Config:         nil,
+			},
+		},
+		"pullSecretName is not nil but addon secrets are nil": {
+			AddonMeta: &v1alpha1.AddonMetadataSpec{
+				PullSecretName: "test-pull-secret",
+				Config: &mtsrev1.Config{
+					Secrets: nil,
+				},
+			},
+		},
+		"pullSecretName is not nil but not present secret": {
+			AddonMeta: &v1alpha1.AddonMetadataSpec{
+				PullSecretName: "test-pull-secret",
+				Config: &mtsrev1.Config{
+					Secrets: &[]mtsrev1.Secret{
+						{
+							Name: "test-pull",
+						},
+						{
+							Name: "alpha",
+						},
+						{
+							Name: "beta",
+						},
+					},
+				},
+			},
+		},
+	})
+}

--- a/pkg/validator/register/register.go
+++ b/pkg/validator/register/register.go
@@ -17,4 +17,5 @@ import (
 	_ "github.com/mt-sre/addon-metadata-operator/pkg/validator/am0015"
 	_ "github.com/mt-sre/addon-metadata-operator/pkg/validator/am0016"
 	_ "github.com/mt-sre/addon-metadata-operator/pkg/validator/am0017"
+	_ "github.com/mt-sre/addon-metadata-operator/pkg/validator/am0018"
 )


### PR DESCRIPTION
Signed-off-by: Ankit Kurmi <akurmi@redhat.com>

# AM0018

## Description

Addon pullSecretName is the name of the secret under `secrets` which is supposed to be used for pulling Catalog Image under CatalogSource. As of now, there is no check to validate if pullSecretName is not nil, it is a part of secrets. 

This validator ensures the same.

