### PR TITLE
ci: use goreleaser 1.19 image

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM ghcr.io/goreleaser/goreleaser-cross:v1.18.1
+FROM ghcr.io/goreleaser/goreleaser-cross:v1.19.3
 
 COPY . /go/src/github.com/mt-sre/addon-metadata-operator
 


### PR DESCRIPTION
### Summary

Bumps goreleaser-cross image to go 1.19