### PR TITLE
feat: deprecating manualInstallApproval

### DIFF
--- a/api/v1alpha1/addonmetadata_types.go
+++ b/api/v1alpha1/addonmetadata_types.go
@@ -149,9 +149,6 @@ type AddonMetadataSpec struct {
 	AddonNotifications *[]mtsrev1.Notification `json:"addonNotifications"`
 
 	// +optional
-	ManualInstallPlanApproval *bool `json:"manualInstallPlanApproval"`
-
-	// +optional
 	// Labels to be applied to all objects created in the SelectorSyncSet.
 	CommonLabels *map[string]string `json:"commonLabels"`
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -311,11 +311,6 @@ func (in *AddonMetadataSpec) DeepCopyInto(out *AddonMetadataSpec) {
 			copy(*out, *in)
 		}
 	}
-	if in.ManualInstallPlanApproval != nil {
-		in, out := &in.ManualInstallPlanApproval, &out.ManualInstallPlanApproval
-		*out = new(bool)
-		**out = **in
-	}
 	if in.CommonLabels != nil {
 		in, out := &in.CommonLabels, &out.CommonLabels
 		*out = new(map[string]string)


### PR DESCRIPTION
## Description

Deprecating `ManualInstallPlanApproval` from the metadata api.

## Checklist

- [ ] Wiki page exists: https://github.com/mt-sre/addon-metadata-operator/wiki/AMxxx
- [ ] Followed the SOP: https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/MT-SRE/sops/AMO-validators.md
- [ ] Tested against production addons in `managed-tenants/addons/`
