### PR TITLE
feat: adding automatic ok-to-test label for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     interval: daily
   labels:
   - kind/deps
+  - ok-to-test
   commit-message:
     prefix: fix
     include: scope
@@ -15,6 +16,7 @@ updates:
     interval: daily
   labels:
   - kind/deps
+  - ok-to-test
   commit-message:
     prefix: fix
     include: scope


### PR DESCRIPTION
## Description

Adding automatic `ok-to-test` label for dependency updates

A short description of my validator and what it is meant to accomplish.

## Checklist

- [ ] Wiki page exists: https://github.com/mt-sre/addon-metadata-operator/wiki/AMxxx
- [ ] Followed the SOP: https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/MT-SRE/sops/AMO-validators.md
- [ ] Tested against production addons in `managed-tenants/addons/`
