### PR TITLE
Adding new enum 'fast' for rhods recent annotation changes

### DIFF
--- a/pkg/validator/am0001/default_channel.go
+++ b/pkg/validator/am0001/default_channel.go
@@ -65,6 +65,7 @@ func (d *DefaultChannel) isPartOfEnum(defaultChannel string) validator.Result {
 		"stable": {},
 		"edge":   {},
 		"rc":     {},
+		"fast":   {},
 	}
 	if _, ok := enum[defaultChannel]; !ok {
 		msg := fmt.Sprintf("The defaultChannel '%v' is not part of the accepted values: alpha, beta, stable, edge or rc.", defaultChannel)


### PR DESCRIPTION
# AM0001

## Description
Added new enum `fast` for rhods recent annotation changes.

A short description of my validator and what it is meant to accomplish.

## Checklist

- [ ] Wiki page exists: https://github.com/mt-sre/addon-metadata-operator/wiki/AMxxx
- [ ] Followed the SOP: https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/MT-SRE/sops/AMO-validators.md
- [ ] Tested against production addons in `managed-tenants/addons/`
